### PR TITLE
Changing reward type and activating other/creating new character now works

### DIFF
--- a/app/Helpers/CharacterHandler.php
+++ b/app/Helpers/CharacterHandler.php
@@ -10,19 +10,22 @@ class CharacterHandler {
 
     public static function toggleCharacterActive($userId, $characterIdToActive){
         $allCharacters = CharacterHandler::findAllCharactersByUser($userId);
+        $activeCharacter = null;
         foreach($allCharacters as $char){
             if($char->id == $characterIdToActive){
-                CharacterHandler::activateCharacter($char->id);
+                $activeCharacter = CharacterHandler::activateCharacter($char->id);
             } else {
                 CharacterHandler::deactivateCharacter($char->id);
             }
         }
+        return $activeCharacter;
     }
 
     public static function activateCharacter($characterId){
         $character = Character::find($characterId);
         $character->active = true;
         $character->update();
+        return $character;
     }
 
     public static function deactivateCharacter($characterId){
@@ -36,6 +39,7 @@ class CharacterHandler {
             'name' => $characterName,
             'user_id' => $userId]);
         CharacterHandler::toggleCharacterActive($userId, $newCharacter->id);
+        return $newCharacter;
     }
 
     public static function findActiveCharacter($userId){

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\CharacterHandler;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\JsonResponse;
 use App\Models\Character;
@@ -15,7 +16,7 @@ class DashboardController extends Controller
         $taskLists = TaskListResource::collection($user->taskLists);
         $character = null;
         if($user->rewards == 'CHARACTER'){
-            $character = new CharacterResource(Character::where('user_id', $user->id)->get()->first());
+            $character = new CharacterResource(CharacterHandler::findActiveCharacter($user->id));
         }
         return new JsonResponse(['taskLists' => $taskLists, 'character' => $character]);
     }

--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\CharacterHandler;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
@@ -15,7 +16,7 @@ class OverviewController extends Controller
         $user = Auth::user();
         $character = null;
         if($user->rewards == 'CHARACTER'){
-            $character = new CharacterResource(Character::where('user_id', $user->id)->get()->first());
+            $character = new CharacterResource(CharacterHandler::findActiveCharacter($user->id));
         }
         $achievements = $user->achievements;
         $stats = new StatsResource($user);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Http\Resources\CharacterResource;
 use App\Http\Resources\UserProfileResource;
 use App\Http\Resources\StatsResource;
 use App\Http\Resources\UserResource;
@@ -62,14 +63,18 @@ class UserController extends Controller
         $validated = $request->validated();
         $user = Auth::user();
         $user->update($validated);
+        $activeReward = null;
         if($request['rewards'] == 'CHARACTER' && $request['keepCharacter'] == 'NEW'){
-            CharacterHandler::createNewCharacterAndActivate($user->id, $request['character_name']);
+            $character = CharacterHandler::createNewCharacterAndActivate($user->id, $request['character_name']);
+            $activeReward = new CharacterResource($character);
         } else if($request['rewards'] == 'CHARACTER' && is_numeric($request['keepCharacter'])){
-            CharacterHandler::toggleCharacterActive($user->id, $request['keepCharacter']);
+            $character = CharacterHandler::toggleCharacterActive($user->id, $request['keepCharacter']);
+            $activeReward = new CharacterResource($character);
         }
         return new JsonResponse([
             'message' => ['message' => ['Your rewards type has been changed.']], 
-            'user' => new UserResource($user)],
+            'user' => new UserResource($user),
+            'activeReward' => $activeReward],
             Response::HTTP_OK);
     }
 

--- a/resources/js/components/modals/ChangeRewardType.vue
+++ b/resources/js/components/modals/ChangeRewardType.vue
@@ -42,7 +42,7 @@
                     :label="$t('character-name')"
                     label-for="character_name">
                 <p class="silent">{{ $t('change-name-later') }}</p>
-                <input 
+                <b-form-input 
                     type="text" 
                     id="character_name" 
                     name="character_name" 
@@ -73,7 +73,7 @@ import { mapGetters } from 'vuex';
         data() {
             return {
                 user: {
-                    rewards: "NONE",
+                    rewards: "",
                     existingCharacter: {},
                     keepCharacter: false,
                 },
@@ -82,31 +82,23 @@ import { mapGetters } from 'vuex';
         },
         methods: {
             confirmRewardsType() {
-                console.log('confirmed rewards type');
                 //TODO For future options such as village, change this to an if-else or switch
                 if(this.user.rewards == 'CHARACTER'){
-                    console.log('chose character');
                     this.$store.dispatch('character/fetchAllCharacters').then(() => {
-                        this.hasCharacter = !!this.characters.length;//Object.entries(this.character).length;
+                        this.hasCharacter = !!this.characters.length;
                         this.$bvModal.hide('change-reward-type');
-                        console.log('checking if has character');
                         if(!this.hasCharacter){
-                            console.log('has no character');
                             this.$bvModal.show('new-character');
                         } else {
-                            console.log('has character');
                             this.$bvModal.show('character-options');
                         }
                     });
                 } else {
-                    console.log('no rewards');
                     this.confirmNewRewardsType();
                 }
             },
             confirmCharacterOptions(){
-                console.log('confirming character options');
                 if(this.user.keepCharacter == 'NEW'){
-                    console.log('wants new character');
                     this.$bvModal.hide('character-options');
                     this.$bvModal.show('new-character');
                 } else {
@@ -114,7 +106,6 @@ import { mapGetters } from 'vuex';
                 }
             },
             checkCharacterInput(){
-                console.log('checking character input');
                 if(this.user.rewards == "CHARACTER" && this.user.keepCharacter == 'NEW' && !this.user.character_name){
                     this.$store.commit('setErrorMessages', {message: ["No character name given."]});
                     return false;
@@ -124,7 +115,6 @@ import { mapGetters } from 'vuex';
                 }
             },
             confirmNewRewardsType() {
-                console.log('confirming new rewards type');
                 if(this.checkCharacterInput()){
                     this.$store.dispatch('user/changeRewardType', this.user).then(response => {
                         this.cancel();
@@ -132,7 +122,6 @@ import { mapGetters } from 'vuex';
                 }
             },
             cancel(){
-                console.log('closing');
                 this.$emit('close');
             }
         },

--- a/resources/js/components/modals/ChangeRewardType.vue
+++ b/resources/js/components/modals/ChangeRewardType.vue
@@ -73,7 +73,7 @@ import { mapGetters } from 'vuex';
         data() {
             return {
                 user: {
-                    rewards: "",
+                    rewards: "NONE",
                     existingCharacter: {},
                     keepCharacter: false,
                 },

--- a/resources/js/pages/Settings.vue
+++ b/resources/js/pages/Settings.vue
@@ -96,9 +96,7 @@
             <b-button type="submit" block>{{ $t('update-email') }}</b-button>
         </b-form>
 
-    <b-modal id="change-reward-type" hide-footer :title="$t('change-reward-type')">
-        <change-reward-type @close="closeChangeRewardType" :rewardsType="user.rewards"></change-reward-type>
-    </b-modal>
+        <change-reward-type v-if="isChangeRewardTypeVisible" @close="closeChangeRewardType" :rewardsType="user.rewards"></change-reward-type>
         
     </div>
 </template>
@@ -123,6 +121,7 @@ export default {
             passwordSettings: {},
             loading: true,
             rewardTypes: REWARD_TYPES,
+            isChangeRewardTypeVisible: false,
         }
     },
     computed: {
@@ -151,10 +150,10 @@ export default {
             this.$store.dispatch('user/updateEmail', this.emailSettings);
         },
         showChangeRewardType(){
-            this.$bvModal.show('change-reward-type');
+            this.isChangeRewardTypeVisible = true;
         },
         closeChangeRewardType(){
-            this.$bvModal.hide('change-reward-type');
+            this.isChangeRewardTypeVisible = false;
         },
     },
 }

--- a/resources/js/store/modules/taskStore.js
+++ b/resources/js/store/modules/taskStore.js
@@ -37,9 +37,9 @@ export default {
                 commit('taskList/setTaskLists', response.data.data, {root:true});
             });
         },
-        completeTask: ({commit}, task) => {
+        completeTask: ({commit, dispatch}, task) => {
             axios.put('/tasks/complete/' + task.id).then(response => {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
                 commit('taskList/setTaskLists', response.data.data, {root:true});
                 commit('character/setCharacter', response.data.character, {root:true});
             });

--- a/resources/js/store/modules/userStore.js
+++ b/resources/js/store/modules/userStore.js
@@ -121,9 +121,7 @@ export default {
             return axios.put('/user/settings/rewards', user).then(response => {
                 commit('setUser', response.data.user);
                 commit('setResponseMessage', response.data.message, {root:true});
-                console.log(response.data.user.rewards);
                 if(response.data.user.rewards == 'CHARACTER'){
-                    console.log('activating character');
                     commit('character/setCharacter', response.data.activeReward, {root:true});
                 }
                 return Promise.resolve();

--- a/resources/js/store/modules/userStore.js
+++ b/resources/js/store/modules/userStore.js
@@ -121,6 +121,11 @@ export default {
             return axios.put('/user/settings/rewards', user).then(response => {
                 commit('setUser', response.data.user);
                 commit('setResponseMessage', response.data.message, {root:true});
+                console.log(response.data.user.rewards);
+                if(response.data.user.rewards == 'CHARACTER'){
+                    console.log('activating character');
+                    commit('character/setCharacter', response.data.activeReward, {root:true});
+                }
                 return Promise.resolve();
             });
         },

--- a/resources/js/store/store.js
+++ b/resources/js/store/store.js
@@ -57,6 +57,10 @@ export default new Vuex.Store({
                 commit('taskList/setTaskLists', response.data.taskLists, {root:true});
                 commit('character/setCharacter', response.data.character, {root:true});
             });
-        }
+        },
+        sendToasts({}, messages){
+            Object.keys(messages).forEach(msg => toastService.$emit('message', {message: messages[msg], variant: "sucess"}));
+        },
+
     }
 });


### PR DESCRIPTION
The problem with the modal for changing the reward type was the fact that the modal was inside a modal. The initial modal was shown twice and caused any other modals to close as if information was submitted. The component is now no longer inside a modal and instead works with a v-if structure. 
The problem with activating the character was due to Home and Overview not fetching the active character, but rather the first found. The back-end was working properly, but the information was not set. Now the back-end resources for Home and Overview fetches the 'active character' using the handler, and updating the active character now sends the active character back. The vue store now sets this active character.
Resolves #163 
Resolves #173 