### PR TITLE
Bug: not all achievements on adding tasks from welcome screen

### DIFF
--- a/app/Helpers/AchievementHandler.php
+++ b/app/Helpers/AchievementHandler.php
@@ -29,6 +29,7 @@ class AchievementHandler {
 
     public static function checkAchievementEligible($user, $type, $amount){
         $achievement = Achievement::where('trigger_type', $type)->where('trigger_amount', $amount)->first();
+        //Rather than the first, get all
         if($achievement && !AchievementHandler::checkIfAchievementEarned($user, $achievement)){
             AchievementHandler::awardAchievement($user, $achievement);
         }

--- a/app/Helpers/AchievementHandler.php
+++ b/app/Helpers/AchievementHandler.php
@@ -28,10 +28,13 @@ class AchievementHandler {
     }
 
     public static function checkAchievementEligible($user, $type, $amount){
-        $achievement = Achievement::where('trigger_type', $type)->where('trigger_amount', $amount)->first();
-        //Rather than the first, get all
-        if($achievement && !AchievementHandler::checkIfAchievementEarned($user, $achievement)){
-            AchievementHandler::awardAchievement($user, $achievement);
+        $achievements = Achievement::where('trigger_type', $type)->where('trigger_amount', '<=', $amount)->get();
+        if($achievements){
+            foreach($achievements as $achievement){
+                if(!AchievementHandler::checkIfAchievementEarned($user, $achievement)){
+                    AchievementHandler::awardAchievement($user, $achievement);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Rather than getting the 'first' achievement when checking, now get all eligible achievements and check one by one.

Resolves #159 