### PR TITLE
Added parseInt

### DIFF
--- a/resources/js/components/modals/NewAchievement.vue
+++ b/resources/js/components/modals/NewAchievement.vue
@@ -70,6 +70,7 @@ export default {
     },
     methods: {
         submitAchievement(){
+            this.achievement.trigger_amount = parseInt(this.achievement.trigger_amount);
             this.$store.dispatch('admin/newAchievement', this.achievement).then(response => {
                 this.close();
             });


### PR DESCRIPTION
Added a simple parseInt to the sending functionality in the front-end to ensure the number is always parsed before it reaches back-end validation