### PR TITLE
Reworked the toast system

### DIFF
--- a/app/Helpers/LevelHandler.php
+++ b/app/Helpers/LevelHandler.php
@@ -48,7 +48,7 @@ class LevelHandler {
                 $returnMessage->$key = (array)$message;
             }
         }
-        $returnMessage->complete = ['Task completed.'];
+        $returnMessage->success = ['Task completed.'];
         $returnValue = new \stdClass();
         $returnValue->character = $character; //Add the newly levelled character on the return value
         $returnValue->message = $returnMessage; //As well as the messages for the user.

--- a/app/Http/Controllers/AchievementController.php
+++ b/app/Http/Controllers/AchievementController.php
@@ -17,7 +17,7 @@ class AchievementController extends Controller
         $validated['trigger_description'] = $this->parseTrigger($validated['trigger_amount'], $validated['trigger_type']);
         Achievement::create($validated);
 
-        return new JsonResponse(['message' => ['message' => ["Achievement added."]], 'achievements' => AchievementResource::collection(Achievement::get())], Response::HTTP_OK);
+        return new JsonResponse(['message' => ['success' => ["Achievement added."]], 'achievements' => AchievementResource::collection(Achievement::get())], Response::HTTP_OK);
     }
 
     public function showAll(){
@@ -33,7 +33,7 @@ class AchievementController extends Controller
         $validated['trigger_description'] = $this->parseTrigger($validated['trigger_amount'], $validated['trigger_type']);
         $achievement->update($validated);
 
-        return new JsonResponse(['message' => ['message' => ["Achievement updated."]], 'achievements' => AchievementResource::collection(Achievement::get())], Response::HTTP_OK);
+        return new JsonResponse(['message' => ['success' => ["Achievement updated."]], 'achievements' => AchievementResource::collection(Achievement::get())], Response::HTTP_OK);
     }
 
     public function destroy(Achievement $achievement){

--- a/app/Http/Controllers/AuthenticationController.php
+++ b/app/Http/Controllers/AuthenticationController.php
@@ -19,7 +19,7 @@ class AuthenticationController extends Controller
             return new JsonResponse(['user' => new UserResource(Auth::user())]);
         }
         $errorMessage = 'Username or password is incorrect.';
-        return new JsonResponse(['message' => ['Username or password is incorrect.'], 'errors' => ['error' => [$errorMessage]]], Response::HTTP_UNPROCESSABLE_ENTITY);
+        return new JsonResponse(['message' => [$errorMessage], 'errors' => ['error' => [$errorMessage]]], Response::HTTP_UNPROCESSABLE_ENTITY);
 
     }
 

--- a/app/Http/Controllers/AuthenticationController.php
+++ b/app/Http/Controllers/AuthenticationController.php
@@ -18,8 +18,8 @@ class AuthenticationController extends Controller
             $request->session()->regenerate();
             return new JsonResponse(['user' => new UserResource(Auth::user())]);
         }
-        $errorMessage = "Username or password is incorrect.";
-        return new JsonResponse(['message' => $errorMessage, 'errors' => ['error' => [$errorMessage]]], Response::HTTP_UNPROCESSABLE_ENTITY);
+        $errorMessage = 'Username or password is incorrect.';
+        return new JsonResponse(['message' => ['Username or password is incorrect.'], 'errors' => ['error' => [$errorMessage]]], Response::HTTP_UNPROCESSABLE_ENTITY);
 
     }
 

--- a/app/Http/Controllers/CharacterController.php
+++ b/app/Http/Controllers/CharacterController.php
@@ -32,7 +32,7 @@ class CharacterController extends Controller
 
         $character = new CharacterResource($character);
         
-        return new JsonResponse(['message' => ['message' => ["Character successfully updated."]], 'data' => $character], Response::HTTP_OK);
+        return new JsonResponse(['message' => ['success' => ["Character successfully updated."]], 'data' => $character], Response::HTTP_OK);
     }
 
     public function getExperienceTable(){

--- a/app/Http/Controllers/FriendController.php
+++ b/app/Http/Controllers/FriendController.php
@@ -26,7 +26,7 @@ class FriendController extends Controller
         $inverseFriendship = Friend::where('user_id', $friend->friend_id)->where('friend_id', Auth::user()->id)->first();
         $friend->delete();
         $inverseFriendship->delete();
-        return new JsonResponse(['message' => ['message' => ['Friend removed.']], 
+        return new JsonResponse(['message' => ['info' => ['Friend removed.']], 
             'user' => new UserResource(Auth::user())], 
             Response::HTTP_OK);
     }
@@ -40,7 +40,7 @@ class FriendController extends Controller
             'user_id' => $user->id,
             'title' => 'New friend request!',
             'text' => 'You have a new friend request from '.Auth::user()->username.'. Would you like to accept?']);
-        return new JsonResponse(['message' => ['message' => ['Friend request successfully sent.']]], Response::HTTP_OK);
+        return new JsonResponse(['message' => ['success' => ['Friend request successfully sent.']]], Response::HTTP_OK);
     }
 
     public function acceptFriendRequest(Friend $friend){
@@ -52,7 +52,7 @@ class FriendController extends Controller
         AchievementHandler::checkForAchievement('FRIENDS', $friend->friend);
 
         $requests = $this->fetchRequests();
-        return new JsonResponse(['message' => ['message' => ['Friend request accepted. You are now friends.']], 
+        return new JsonResponse(['message' => ['success' => ['Friend request accepted. You are now friends.']], 
             'user' => new UserResource(Auth::user()),
             'requests' => $requests], 
             Response::HTTP_OK);
@@ -61,7 +61,7 @@ class FriendController extends Controller
     public function denyFriendRequest(Friend $friend){
         $friend->delete();
         $requests = $this->fetchRequests();
-        return new JsonResponse(['message' => ['message' => ['Friend request denied.']], 
+        return new JsonResponse(['message' => ['info' => ['Friend request denied.']], 
             'requests' => $requests], 
             Response::HTTP_OK);
     }

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -49,6 +49,6 @@ class NotificationController extends Controller
             'title' => $validated['title'],
             'text' => $validated['text']]);
         }
-        return new JsonResponse(['message' => ['message' => ['Notification sent.']]]);
+        return new JsonResponse(['message' => ['success' => ['Notification sent.']]]);
     }
 }

--- a/app/Http/Controllers/RegisteredUserController.php
+++ b/app/Http/Controllers/RegisteredUserController.php
@@ -23,7 +23,7 @@ class RegisteredUserController extends Controller
         $validated['password'] = bcrypt($validated['password']);
         $user = User::create($validated);
         $successMessage = "You have successfully registered. You can now login with your chosen username.";
-        return new JsonResponse(['message' => ['message' => [$successMessage]]], Response::HTTP_OK);
+        return new JsonResponse(['message' => ['sucess' => [$successMessage]]], Response::HTTP_OK);
     }
 
     public function confirmRegister(ConfirmRegisterRequest $request): JsonResponse{
@@ -50,7 +50,7 @@ class RegisteredUserController extends Controller
         $user->first_login = false;
         $user->save();
         $successMessage = "You have successfully set up your account.";
-        return new JsonResponse(['message' => ['message' => [$successMessage]], 'user' => new UserResource(Auth::user())]);
+        return new JsonResponse(['message' => ['success' => [$successMessage]], 'user' => new UserResource(Auth::user())]);
     }
 
     private function addExampleTasks($tasks, $userId, $taskListId){

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -27,7 +27,7 @@ class TaskController extends Controller
 
         $taskLists = TaskListResource::collection(TaskList::where('user_id', Auth::user()->id)->get());
 
-        return new JsonResponse(['message' => ['message' => ["Task successfully created."]], 'data' => $taskLists], Response::HTTP_OK);
+        return new JsonResponse(['message' => ['success' => ["Task successfully created."]], 'data' => $taskLists], Response::HTTP_OK);
     }
 
     public function update(Task $task, UpdateTaskRequest $request){
@@ -36,7 +36,7 @@ class TaskController extends Controller
 
         $taskLists = TaskListResource::collection(Auth::user()->taskLists);
         
-        return new JsonResponse(['message' => ['message' => ["Task successfully updated."]], 'data' => $taskLists], Response::HTTP_OK);
+        return new JsonResponse(['message' => ['success' => ["Task successfully updated."]], 'data' => $taskLists], Response::HTTP_OK);
     }
 
     public function destroy(Task $task): JsonResponse
@@ -46,7 +46,7 @@ class TaskController extends Controller
             $task->delete();
 
             $taskLists = TaskListResource::collection(Auth::user()->taskLists);
-            return new JsonResponse(['message' => ['message' => ["Task successfully deleted."]], 'data' => $taskLists], Response::HTTP_OK);
+            return new JsonResponse(['message' => ['info' => ["Task deleted."]], 'data' => $taskLists], Response::HTTP_OK);
         } else {
             return new JsonResponse(['errors' => ['error' => ["You are not authorized to delete this task"]]], Response::HTTP_FORBIDDEN);
         }
@@ -71,7 +71,7 @@ class TaskController extends Controller
                 $returnValue = $character->applyReward($task);
                 return new JsonResponse(['message' => $returnValue->message, 'data' => $taskLists, 'character' => new CharacterResource($character->fresh())], Response::HTTP_OK);
             } else {
-                return new JsonResponse(['message' => ['message' => ['Task completed.']], 'data' => $taskLists], Response::HTTP_OK);
+                return new JsonResponse(['message' => ['success' => ['Task completed.']], 'data' => $taskLists], Response::HTTP_OK);
             }
         } else {
             return new JsonResponse(['errors' => ['error' => ["You are not authorized to complete this task"]]], Response::HTTP_FORBIDDEN);

--- a/app/Http/Controllers/TaskListController.php
+++ b/app/Http/Controllers/TaskListController.php
@@ -22,7 +22,7 @@ class TaskListController extends Controller
         TaskList::create($validated);
 
         $taskLists = TaskListResource::collection(Auth::user()->taskLists);
-        return new JsonResponse(['message' => ['message' => ['Task list successfully created.']], 'data' => $taskLists], Response::HTTP_OK);
+        return new JsonResponse(['message' => ['success' => ['Task list successfully created.']], 'data' => $taskLists], Response::HTTP_OK);
     }
 
     public function update(TaskList $tasklist, UpdateTaskListRequest $request): JsonResponse
@@ -31,7 +31,7 @@ class TaskListController extends Controller
         $tasklist->update($validated);
 
         $taskLists = TaskListResource::collection(Auth::user()->taskLists);
-        return new JsonResponse(['message' => ['message' => ["Task list successfully updated."]], 'data' => $taskLists], Response::HTTP_OK);
+        return new JsonResponse(['message' => ['success' => ["Task list updated."]], 'data' => $taskLists], Response::HTTP_OK);
     }
 
     public function destroy(TaskList $tasklist): JsonResponse
@@ -41,7 +41,7 @@ class TaskListController extends Controller
             $tasklist->delete();
 
             $taskLists = TaskListResource::collection(Auth::user()->taskLists);
-            return new JsonResponse(['message' => ['message' => ["Task list successfully deleted."]], 'data' => $taskLists], Response::HTTP_OK);
+            return new JsonResponse(['message' => ['info' => ["Task list deleted."]], 'data' => $taskLists], Response::HTTP_OK);
         } else {
             return new JsonResponse(['errors' => ['error' => ["You are not authorized to delete this task list"]]], Response::HTTP_FORBIDDEN);
         }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -40,21 +40,21 @@ class UserController extends Controller
         //Invalidate old e-mail
         //Send new e-mail confirmation
         //Update new e-mail, unconfirmed
-        return new JsonResponse(['message' => ['message' => ['Your email has been changed.']], 'user' => new UserResource(Auth::user())], Response::HTTP_OK);
+        return new JsonResponse(['message' => ['success' => ['Your email has been changed.']], 'user' => new UserResource(Auth::user())], Response::HTTP_OK);
     }
 
     public function updatePassword(UpdateUserPasswordRequest $request){
         $validated = $request->validated();
         $validated['password'] = bcrypt($validated['password']);
         Auth::user()->update($validated);
-        return new JsonResponse(['message' => ['message' => ['Your password has been updated. Please log in using your new password.']]], Response::HTTP_OK);
+        return new JsonResponse(['message' => ['success' => ['Your password has been updated. Please log in using your new password.']]], Response::HTTP_OK);
     }
 
     public function updateSettings(UpdateUserSettingsRequest $request){
         $validated = $request->validated();
         Auth::user()->update($validated);
         return new JsonResponse([
-            'message' => ['message' => ['Your settings have been changed.']], 
+            'message' => ['success' => ['Your settings have been changed.']], 
             'user' => new UserResource(Auth::user())],
             Response::HTTP_OK);
     }
@@ -72,7 +72,7 @@ class UserController extends Controller
             $activeReward = new CharacterResource($character);
         }
         return new JsonResponse([
-            'message' => ['message' => ['Your rewards type has been changed.']], 
+            'message' => ['success' => ['Your rewards type has been changed.']], 
             'user' => new UserResource($user),
             'activeReward' => $activeReward],
             Response::HTTP_OK);

--- a/resources/js/interceptors.js
+++ b/resources/js/interceptors.js
@@ -38,14 +38,15 @@ axios.interceptors.response.use(
                 if (router.currentRoute.name !== 'login') {
                     store.dispatch('user/logout', false);
                 }
-                sendError('You are not logged in', 'danger', error.response.data.errors || []);
+                sendErrorToast('You are not logged in');
                 return Promise.reject(error, false);
             // user tried to access unauthorized resource
             case 403:
-                sendError('You are not authorized for this action', 'danger', error.response.data.errors || []);
+                sendErrorToast('You are not authorized for this action');
                 return Promise.reject(error);
             case 422:
-                sendError('There were errors in the form', 'danger', error.response.data.errors || []);
+                sendErrorToast();
+                store.commit('setErrorMessages', errors);
                 return Promise.reject(error);
             default:
                 return Promise.reject(error);
@@ -53,7 +54,6 @@ axios.interceptors.response.use(
     }
 );
 
-function sendError(toastMessage, toastVariant, errors){
-    store.commit('setErrorMessages', errors);
-    toastService.$emit('message', {message: toastMessage, variant: toastVariant});
+function sendErrorToast(toastMessage){
+    toastService.$emit('message', {message: toastMessage, variant: 'danger'});
 }

--- a/resources/js/interceptors.js
+++ b/resources/js/interceptors.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import router from './router/router.js';
 import store from './store/store.js';
-import toastService from '../js/services/toastService';
 
 window.axios = axios;
 
@@ -45,8 +44,8 @@ axios.interceptors.response.use(
                 sendErrorToast('You are not authorized for this action');
                 return Promise.reject(error);
             case 422:
-                sendErrorToast();
-                store.commit('setErrorMessages', errors);
+                sendErrorToast(error.response.data.message);
+                store.commit('setErrorMessages', error.response.data.errors);
                 return Promise.reject(error);
             default:
                 return Promise.reject(error);
@@ -55,5 +54,6 @@ axios.interceptors.response.use(
 );
 
 function sendErrorToast(toastMessage){
-    toastService.$emit('message', {message: toastMessage, variant: 'danger'});
+    let toastObject = {'error': toastMessage};
+    store.dispatch('sendToasts', toastObject)
 }

--- a/resources/js/services/toastService.js
+++ b/resources/js/services/toastService.js
@@ -4,8 +4,8 @@ import Vue from 'vue';
 
 const toastService = new Vue();
 
-const messageHandler = ({message, variant}) => {
-    const title = getTitle(variant);
+const messageHandler = ({message, key}) => {
+    const {title, variant} = getTitleAndVariant(key);
 
     toastService.$app.$bvToast.toast(message, {
         title,
@@ -17,30 +17,36 @@ const messageHandler = ({message, variant}) => {
     });
 };
 
-const getTitle = (variant) => {
-    let title;
+const getTitleAndVariant = (variant) => {
+    let variables = {};
     switch(variant){
         case 'danger':
-            title = 'Error';
+        case 'error':
+            variables.title = 'Error';
+            variables.variant = 'danger';
             break;
         case 'success':
-            title = 'Success';
+            variables.title = 'Success';
+            variables.variant = 'success';
             break;
         case 'warning':
-            title = 'Warning';
+            variables.title = 'Warning';
+            variables.variant = 'warning';
             break;
         case 'info':
-            title = 'Info';
+        default:
+            variables.title = 'Info';
+            variables.variant = 'info';
             break;
     }
-    return title;
+    return variables;
 }
 
 toastService.$on('message', messageHandler);
 
 /**
  * How to send a toast:
- * toastService.$emit('message', {message: insertMessage, variant: insertVariable});
+ * toastService.$emit('message', {message: insertMessage, variant: insertVariant});
  * Info: blue
  * Warning: yellow
  * Danger: red

--- a/resources/js/services/toastService.js
+++ b/resources/js/services/toastService.js
@@ -5,7 +5,7 @@ import Vue from 'vue';
 const toastService = new Vue();
 
 const messageHandler = ({message, variant}) => {
-    const title = variant == 'danger' ? 'Error' : 'Success';
+    const title = getTitle(variant);
 
     toastService.$app.$bvToast.toast(message, {
         title,
@@ -17,6 +17,34 @@ const messageHandler = ({message, variant}) => {
     });
 };
 
+const getTitle = (variant) => {
+    let title;
+    switch(variant){
+        case 'danger':
+            title = 'Error';
+            break;
+        case 'success':
+            title = 'Success';
+            break;
+        case 'warning':
+            title = 'Warning';
+            break;
+        case 'info':
+            title = 'Info';
+            break;
+    }
+    return title;
+}
+
 toastService.$on('message', messageHandler);
+
+/**
+ * How to send a toast:
+ * toastService.$emit('message', {message: insertMessage, variant: insertVariable});
+ * Info: blue
+ * Warning: yellow
+ * Danger: red
+ * Success: green
+ */
 
 export default toastService;

--- a/resources/js/store/modules/adminStore.js
+++ b/resources/js/store/modules/adminStore.js
@@ -21,21 +21,21 @@ export default {
         },
         newAchievement: ({commit}, achievement) => {
             return axios.post('/achievements', achievement).then(response => {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
                 commit('achievement/setAchievements', response.data.achievements, {root:true});
                 return Promise.resolve();
             });
         },
         editAchievement: ({commit}, achievement) => {
             return axios.put('/achievements/' + achievement.id, achievement).then(response => {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
                 commit('achievement/setAchievements', response.data.achievements, {root:true});
                 return Promise.resolve();
             });
         },
         sendNotification: ({commit}, notification) => {
             axios.post('/notifications/all', notification).then(response => {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
             });
         },
     },

--- a/resources/js/store/modules/adminStore.js
+++ b/resources/js/store/modules/adminStore.js
@@ -19,21 +19,21 @@ export default {
         checkAdmin: () => {
             axios.get('/isadmin');
         },
-        newAchievement: ({commit}, achievement) => {
+        newAchievement: ({ commit, dispatch }, achievement) => {
             return axios.post('/achievements', achievement).then(response => {
                 dispatch('sendToasts', response.data.message, {root:true});
                 commit('achievement/setAchievements', response.data.achievements, {root:true});
                 return Promise.resolve();
             });
         },
-        editAchievement: ({commit}, achievement) => {
+        editAchievement: ({ commit, dispatch }, achievement) => {
             return axios.put('/achievements/' + achievement.id, achievement).then(response => {
                 dispatch('sendToasts', response.data.message, {root:true});
                 commit('achievement/setAchievements', response.data.achievements, {root:true});
                 return Promise.resolve();
             });
         },
-        sendNotification: ({commit}, notification) => {
+        sendNotification: ({ commit, dispatch }, notification) => {
             axios.post('/notifications/all', notification).then(response => {
                 dispatch('sendToasts', response.data.message, {root:true});
             });

--- a/resources/js/store/modules/characterStore.js
+++ b/resources/js/store/modules/characterStore.js
@@ -47,7 +47,7 @@ export default {
         //TODO up until here
         updateCharacter: ({commit}, character) => {
             return axios.put('/character/' + character.id, character).then(function(response) {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
                 commit('setCharacter', response.data.data);
                 return Promise.resolve();
             });

--- a/resources/js/store/modules/characterStore.js
+++ b/resources/js/store/modules/characterStore.js
@@ -45,7 +45,7 @@ export default {
         },
 
         //TODO up until here
-        updateCharacter: ({commit}, character) => {
+        updateCharacter: ({ commit, dispatch }, character) => {
             return axios.put('/character/' + character.id, character).then(function(response) {
                 dispatch('sendToasts', response.data.message, {root:true});
                 commit('setCharacter', response.data.data);

--- a/resources/js/store/modules/friendStore.js
+++ b/resources/js/store/modules/friendStore.js
@@ -18,7 +18,7 @@ export default {
         },
     },
     actions: {
-        sendRequest: ({commit}, friendId) => {
+        sendRequest: ({ dispatch }, friendId) => {
             axios.post('/friend/request/' + friendId).then(response => {
                 dispatch('sendToasts', response.data.message, {root:true});
             });
@@ -28,20 +28,20 @@ export default {
                 commit('setRequests', response.data);
             });
         },
-        acceptRequest: ({commit}, requestId) => {
+        acceptRequest: ({ commit, dispatch }, requestId) => {
             axios.post('/friend/request/' + requestId + '/accept').then(response => {
                 dispatch('sendToasts', response.data.message, {root:true});
                 commit('user/setUser', response.data.user, {root:true});
                 commit('setRequests', response.data.requests);
             });
         },
-        denyRequest: ({commit}, requestId) => {
+        denyRequest: ({ commit, dispatch }, requestId) => {
             axios.post('/friend/request/' + requestId + '/deny').then(response => {
                 dispatch('sendToasts', response.data.message, {root:true});
                 commit('setRequests', response.data.requests);
             });
         },
-        removeFriend: ({commit}, friendId) => {
+        removeFriend: ({ commit, dispatch }, friendId) => {
             axios.delete('/friend/remove/' + friendId).then(response => {
                 dispatch('sendToasts', response.data.message, {root:true});
                 commit('user/setUser', response.data.user, {root:true});

--- a/resources/js/store/modules/friendStore.js
+++ b/resources/js/store/modules/friendStore.js
@@ -20,7 +20,7 @@ export default {
     actions: {
         sendRequest: ({commit}, friendId) => {
             axios.post('/friend/request/' + friendId).then(response => {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
             });
         },
         getRequests: ({commit}) => {
@@ -30,20 +30,20 @@ export default {
         },
         acceptRequest: ({commit}, requestId) => {
             axios.post('/friend/request/' + requestId + '/accept').then(response => {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
                 commit('user/setUser', response.data.user, {root:true});
                 commit('setRequests', response.data.requests);
             });
         },
         denyRequest: ({commit}, requestId) => {
             axios.post('/friend/request/' + requestId + '/deny').then(response => {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
                 commit('setRequests', response.data.requests);
             });
         },
         removeFriend: ({commit}, friendId) => {
             axios.delete('/friend/remove/' + friendId).then(response => {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
                 commit('user/setUser', response.data.user, {root:true});
             });
         },

--- a/resources/js/store/modules/taskListStore.js
+++ b/resources/js/store/modules/taskListStore.js
@@ -20,21 +20,21 @@ export default {
     actions: {
         storeTaskList: ({ commit }, taskList) => {
             return axios.post('/tasklists', taskList).then(response => {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
                 commit('setTaskLists', response.data.data);
                 return Promise.resolve();
             });
         },
         updateTaskList: ({ commit }, taskList) => {
             return axios.put('/tasklists/' + taskList.id, taskList).then(response => {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
                 commit('setTaskLists', response.data.data);
                 return Promise.resolve();
             });
         },
         deleteTaskList: ({ commit }, taskList) => {
             axios.delete('/tasklists/' + taskList.id).then(response => {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
                 commit('setTaskLists', response.data.data);
             });
         },

--- a/resources/js/store/modules/taskListStore.js
+++ b/resources/js/store/modules/taskListStore.js
@@ -18,21 +18,21 @@ export default {
         },
     },
     actions: {
-        storeTaskList: ({ commit }, taskList) => {
+        storeTaskList: ({ commit, dispatch }, taskList) => {
             return axios.post('/tasklists', taskList).then(response => {
                 dispatch('sendToasts', response.data.message, {root:true});
                 commit('setTaskLists', response.data.data);
                 return Promise.resolve();
             });
         },
-        updateTaskList: ({ commit }, taskList) => {
+        updateTaskList: ({ commit, dispatch }, taskList) => {
             return axios.put('/tasklists/' + taskList.id, taskList).then(response => {
                 dispatch('sendToasts', response.data.message, {root:true});
                 commit('setTaskLists', response.data.data);
                 return Promise.resolve();
             });
         },
-        deleteTaskList: ({ commit }, taskList) => {
+        deleteTaskList: ({ commit, dispatch }, taskList) => {
             axios.delete('/tasklists/' + taskList.id).then(response => {
                 dispatch('sendToasts', response.data.message, {root:true});
                 commit('setTaskLists', response.data.data);

--- a/resources/js/store/modules/taskStore.js
+++ b/resources/js/store/modules/taskStore.js
@@ -17,27 +17,27 @@ export default {
         },
     },
     actions: {
-        storeTask: ({ commit }, task) => {
+        storeTask: ({ commit, dispatch }, task) => {
             return axios.post('/tasks', task).then(response => {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
                 commit('taskList/setTaskLists', response.data.data, {root:true});
                 return Promise.resolve();
             });
         },
-        updateTask: ({ commit }, task) => {
+        updateTask: ({ commit, dispatch }, task) => {
             return axios.put('/tasks/' + task.id, task).then(response => {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
                 commit('taskList/setTaskLists', response.data.data, {root:true});
                 return Promise.resolve();
             });
         },
-        deleteTask: ({ commit }, task) =>{
+        deleteTask: ({ commit, dispatch }, task) =>{
             axios.delete('/tasks/' + task.id, task).then(response => {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
                 commit('taskList/setTaskLists', response.data.data, {root:true});
             });
         },
-        completeTask: ({commit, dispatch}, task) => {
+        completeTask: ({ commit, dispatch }, task) => {
             axios.put('/tasks/complete/' + task.id).then(response => {
                 dispatch('sendToasts', response.data.message, {root:true});
                 commit('taskList/setTaskLists', response.data.data, {root:true});

--- a/resources/js/store/modules/userStore.js
+++ b/resources/js/store/modules/userStore.js
@@ -73,12 +73,12 @@ export default {
         register: ({ commit }, user) => {
             axios.post('/register', user).then(response => {
                 router.push('/login').catch(() => { });
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
             });
         },
         confirmRegister: ({ commit }, user) => {
             axios.post('/register/confirm', user).then(response => {
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
                 commit('setUser', response.data.user);
                 router.push('/').catch(() => {});
             });
@@ -102,25 +102,25 @@ export default {
         updatePassword: ({commit, dispatch}, passwords) => {
             axios.put('/user/settings/password', passwords).then(response => {
                 dispatch('logout');
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
             });
         },
         updateEmail: ({commit}, email) => {
             axios.put('/user/settings/email', email).then(response => {
                 commit('setUser', response.data.user);
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
             });
         },
         updateSettings: ({commit}, settings) => {
             axios.put('/user/settings', settings).then(response => {
                 commit('setUser', response.data.user);
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
             });
         },
         changeRewardType: ({commit}, user) => {
             return axios.put('/user/settings/rewards', user).then(response => {
                 commit('setUser', response.data.user);
-                commit('setResponseMessage', response.data.message, {root:true});
+                dispatch('sendToasts', response.data.message, {root:true});
                 if(response.data.user.rewards == 'CHARACTER'){
                     commit('character/setCharacter', response.data.activeReward, {root:true});
                 }

--- a/resources/js/store/modules/userStore.js
+++ b/resources/js/store/modules/userStore.js
@@ -70,13 +70,13 @@ export default {
         },
 
         //New user
-        register: ({ commit }, user) => {
+        register: ({ dispatch }, user) => {
             axios.post('/register', user).then(response => {
                 router.push('/login').catch(() => { });
                 dispatch('sendToasts', response.data.message, {root:true});
             });
         },
-        confirmRegister: ({ commit }, user) => {
+        confirmRegister: ({ commit, dispatch }, user) => {
             axios.post('/register/confirm', user).then(response => {
                 dispatch('sendToasts', response.data.message, {root:true});
                 commit('setUser', response.data.user);
@@ -99,25 +99,25 @@ export default {
             });
         },
 
-        updatePassword: ({commit, dispatch}, passwords) => {
+        updatePassword: ({ dispatch }, passwords) => {
             axios.put('/user/settings/password', passwords).then(response => {
                 dispatch('logout');
                 dispatch('sendToasts', response.data.message, {root:true});
             });
         },
-        updateEmail: ({commit}, email) => {
+        updateEmail: ({ commit, dispatch }, email) => {
             axios.put('/user/settings/email', email).then(response => {
                 commit('setUser', response.data.user);
                 dispatch('sendToasts', response.data.message, {root:true});
             });
         },
-        updateSettings: ({commit}, settings) => {
+        updateSettings: ({ commit, dispatch }, settings) => {
             axios.put('/user/settings', settings).then(response => {
                 commit('setUser', response.data.user);
                 dispatch('sendToasts', response.data.message, {root:true});
             });
         },
-        changeRewardType: ({commit}, user) => {
+        changeRewardType: ({ commit, dispatch }, user) => {
             return axios.put('/user/settings/rewards', user).then(response => {
                 commit('setUser', response.data.user);
                 dispatch('sendToasts', response.data.message, {root:true});

--- a/resources/js/store/store.js
+++ b/resources/js/store/store.js
@@ -35,6 +35,7 @@ export default new Vuex.Store({
         setErrorMessages(state, response){
             state.errors = response;
         },
+        //TODO?
         setResponseMessage(state, responseMessage){
             toastService.$emit('message', {message: responseMessage.message[0], variant: "success"});
         },
@@ -58,8 +59,15 @@ export default new Vuex.Store({
                 commit('character/setCharacter', response.data.character, {root:true});
             });
         },
-        sendToasts({}, messages){
-            Object.keys(messages).forEach(msg => toastService.$emit('message', {message: messages[msg], variant: "sucess"}));
+        //Decide which way to go
+        sendToasts({}, messages, variant){
+            Object.keys(messages).forEach(msg => toastService.$emit('message', {message: messages[msg], variant: variant}));
+        },
+        sendErrorToast({}, message){
+            toastService.$emit('message', {message: message, variant: 'danger'});
+        },
+        sendToast({}, {message, variant}){
+            toastService.$emit('message', {message: message, variant: variant});
         },
 
     }

--- a/resources/js/store/store.js
+++ b/resources/js/store/store.js
@@ -35,16 +35,9 @@ export default new Vuex.Store({
         setErrorMessages(state, response){
             state.errors = response;
         },
-        //TODO?
-        setResponseMessage(state, responseMessage){
-            toastService.$emit('message', {message: responseMessage.message[0], variant: "success"});
-        },
     },
     getters: {
         //Errors and response
-        getResponseMessage: (state) => {
-            return state.responseMessage;
-        },
         getErrorMessages: (state) => {
             return state.errors;
         },
@@ -59,15 +52,21 @@ export default new Vuex.Store({
                 commit('character/setCharacter', response.data.character, {root:true});
             });
         },
-        //Decide which way to go
-        sendToasts({}, messages, variant){
-            Object.keys(messages).forEach(msg => toastService.$emit('message', {message: messages[msg], variant: variant}));
-        },
-        sendErrorToast({}, message){
-            toastService.$emit('message', {message: message, variant: 'danger'});
-        },
-        sendToast({}, {message, variant}){
-            toastService.$emit('message', {message: message, variant: variant});
+        /**
+         * Send a toast by calling:
+         * dispatch('sendToasts', response.data.message, {root:true});
+         * where 'response.data.message' is an object with one or multiple messages.
+         * In the JsonResponse, name the response message 'success', 'danger' or 'info' 
+         * to get corresponding themes and titles.
+         * 
+         * @param {*} 
+         * @param {Object} messages 
+         */
+        sendToasts({}, messages){
+            Object.entries(messages).forEach(msg => {
+                const [key, value] = msg;
+                toastService.$emit('message', {message: value, key: key})
+            });
         },
 
     }


### PR DESCRIPTION
Rather than using 'setResponseMessage' mutation to send  a toast, made an action in the store.
Changed the interceptor to set errors and send an error toast.
Changed the toast to accept the message object and use the key for each error/response message as indicator for variant/title. Uses a switch case to set the title and variant accordingly. Defaults to 'info'.
Changed the JsonResponse messages to include the necessary keys in the message.

Resolves #176 
Closes #157