### PR TITLE
Smaller exp table

### DIFF
--- a/app/Helpers/LevelHandler.php
+++ b/app/Helpers/LevelHandler.php
@@ -5,6 +5,7 @@ namespace App\Helpers;
 use Illuminate\Support\Facades\DB;
 use App\Http\Resources\CharacterResource;
 use App\Http\Resources\VillageResource;
+use App\Models\ExperiencePoint;
 
 class LevelHandler {
     /**
@@ -35,7 +36,7 @@ class LevelHandler {
      */
     public static function checkCharacterLevelUp($character){
         $messages = [];
-        $experienceTable =  DB::table('experience_points')->get();
+        $experienceTable =  ExperiencePoint::get();
         for($i = 0 ; $i < count(RewardEnums::CHAR_STAT_ARRAY) ; $i++){
             $expNeeded = $experienceTable->firstWhere('level', $character[RewardEnums::CHAR_STAT_ARRAY[$i]])->experience_points;
             while($character[RewardEnums::CHAR_STAT_EXP_ARRAY[$i]] > $expNeeded){ //While the exp owned is higher than the exp needed to level up:
@@ -80,7 +81,7 @@ class LevelHandler {
      */
     public static function checkVillageLevelUp($village){
         $messages = [];
-        $experienceTable =  DB::table('experience_points')->get();
+        $experienceTable =  ExperiencePoint::get();
         for($i = 0 ; $i < count(RewardEnums::VILL_STAT_ARRAY) ; $i++){
             $expNeeded = $experienceTable->firstWhere('level', $village[RewardEnums::VILL_STAT_ARRAY[$i]])->experience_points;
             while($village[RewardEnums::VILL_STAT_EXP_ARRAY[$i]] > $expNeeded){ //While the exp owned is higher than the exp needed to level up:

--- a/app/Helpers/VariableHandler.php
+++ b/app/Helpers/VariableHandler.php
@@ -5,13 +5,14 @@ namespace App\Helpers;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use App\Helpers\RewardEnums;
+use App\Models\ExperiencePoint;
 
 class VariableHandler {
 
     public static function getExperienceTable(){
         if(!Cache::has('experienceTable')){
             Cache::remember('experienceTable', 60, function () {
-                return DB::table('experience_points')->get();
+                return ExperiencePoint::get();
             });
         }
         return Cache::get('experienceTable');

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -11,6 +11,7 @@ use App\Models\Achievement;
 use App\Models\AchievementTrigger;
 use App\Http\Resources\AchievementResource;
 use App\Models\BugReport;
+use App\Models\ExperiencePoint;
 use App\Http\Resources\BugReportResource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
@@ -22,7 +23,7 @@ class AdminController extends Controller
         $achievements = AchievementResource::collection(Achievement::get());
         $achievementTriggers = AchievementTrigger::get();
         $bugReports = BugReportResource::collection(BugReport::all());
-        $experiencePoints = DB::table('experience_points')->get();
+        $experiencePoints = ExperiencePoint::get();
         $characterExpGain = DB::table('character_exp_gain')->get();
         $villageExpGain = DB::table('village_exp_gain')->get();
         $balancing = ['experience_points' => $experiencePoints, 'character_exp_gain' => $characterExpGain, 'village_exp_gain' => $villageExpGain];
@@ -34,8 +35,8 @@ class AdminController extends Controller
 
     public function updateExeriencePoints(UpdateExperiencePointsRequest $request) {
         $validated = $request->validated();
-        DB::table('experience_points')->upsert($validated, ['id'], ['experience_points']);
-        $experiencePoints = DB::table('experience_points')->get();
+        ExperiencePoint::upsert($validated, ['id'], ['experience_points']);
+        $experiencePoints = ExperiencePoint::get();
         return new JsonResponse(
             ['message' => ['success' => ['Experience points updated']], 'data' => $experiencePoints], 
             Response::HTTP_OK);
@@ -43,8 +44,8 @@ class AdminController extends Controller
 
     public function addNewLevel(StoreNewLevelRequest $request) {
         $validated = $request->validated();
-        DB::table('experience_points')->insert($validated);
-        $experiencePoints = DB::table('experience_points')->get();
+        ExperiencePoint::insert($validated);
+        $experiencePoints = ExperiencePoint::get();
         return new JsonResponse(
             ['message' => ['success' => ['Level added']], 'data' => $experiencePoints], 
             Response::HTTP_OK);

--- a/app/Http/Resources/VillageResource.php
+++ b/app/Http/Resources/VillageResource.php
@@ -29,8 +29,8 @@ class VillageResource extends JsonResource
             'c_exp' => $this->craft_exp,
             'd_exp' => $this->art_exp,
             'e_exp' => $this->community_exp,
+            'exp_to_level' => $this->expToLevel(),
             'rewardType' => 'VILLAGE',
-            'experienceTable' => $this->experienceTable(),
             'active' => !!$this->active,
         ];
     }

--- a/app/Models/Character.php
+++ b/app/Models/Character.php
@@ -48,7 +48,12 @@ class Character extends Model
         return $returnValue;
     }
 
-    public function experienceTable(){
-        return VariableHandler::getExperienceTable();
+    public function expToLevel() {
+        return ExperiencePoint::where('level', $this->strength)
+            ->orWhere('level', $this->agility)
+            ->orWhere('level', $this->endurance)
+            ->orWhere('level', $this->intelligence)
+            ->orWhere('level', $this->charisma)
+            ->orWhere('level', $this->level)->get();
     }
 }

--- a/app/Models/ExperiencePoint.php
+++ b/app/Models/ExperiencePoint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ExperiencePoint extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Village.php
+++ b/app/Models/Village.php
@@ -8,6 +8,7 @@ use App\Helpers\RewardHandler;
 use App\Helpers\LevelHandler;
 use App\Http\Resources\VillageResource;
 use App\Helpers\VariableHandler;
+use App\Models\ExperiencePoint;
 
 class Village extends Model
 {
@@ -33,9 +34,6 @@ class Village extends Model
     public function user(){
         return $this->belongsTo('App\Models\User');
     }
-    public function experienceTable(){
-        return VariableHandler::getExperienceTable();
-    }
 
     /**
      * Applies a reward from a completed task to a village
@@ -49,5 +47,14 @@ class Village extends Model
         $this->update($returnValue->activeReward);
         $returnValue->activeReward = new VillageResource($this);
         return $returnValue;
+    }
+
+    public function expToLevel() {
+        return ExperiencePoint::where('level', $this->economy)
+            ->orWhere('level', $this->labour)
+            ->orWhere('level', $this->craft)
+            ->orWhere('level', $this->art)
+            ->orWhere('level', $this->community)
+            ->orWhere('level', $this->level)->get();
     }
 }

--- a/database/seeders/ExperiencePointsSeeder.php
+++ b/database/seeders/ExperiencePointsSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use App\Models\ExperiencePoint;
 
 class ExperiencePointsSeeder extends Seeder
 {
@@ -16,7 +17,7 @@ class ExperiencePointsSeeder extends Seeder
     {
         $experiencePoints = 1000;
         for($i = 1 ; $i < 101 ; $i++){
-            DB::table('experience_points')->insert([
+            ExperiencePoint::insert([
                 'level' => $i,
                 'experience_points' => $experiencePoints,
             ]);

--- a/resources/js/components/summary/RewardCard.vue
+++ b/resources/js/components/summary/RewardCard.vue
@@ -55,9 +55,9 @@ export default {
          * @param {Number} level
          */
         experienceToLevel(level) {
-            const index = this.reward.experienceTable.findIndex(item => item.level == level);
+            const index = this.reward.exp_to_level.findIndex(item => item.level == level);
             if (index >= 0) {
-                return this.reward.experienceTable[index].experience_points;
+                return this.reward.exp_to_level[index].experience_points;
             }
         },
     },


### PR DESCRIPTION
Rather than sending the entire exp table, it now gets the table for the 6 stats, and the level. At most each request will have 7 different levels.
Also added an ExperiencePoint model to reduce the DB::table calls. May make updating easier in the future.