### PR TITLE
Foreign id with cascade

### DIFF
--- a/database/migrations/2022_02_25_124757_create_blocklist_table.php
+++ b/database/migrations/2022_02_25_124757_create_blocklist_table.php
@@ -19,6 +19,15 @@ class CreateBlocklistTable extends Migration
             $table->unsignedBigInteger('user_id');
             $table->unsignedBigInteger('blocked_user_id');
         });
+        
+        Schema::table('blocklist', function (Blueprint $table){
+            $table->foreign('user_id')
+                ->references('id')->on('users')
+                ->onDelete('cascade');
+            $table->foreign('blocked_user_id')
+                ->references('id')->on('users')
+                ->onDelete('cascade');
+        });
     }
 
     /**

--- a/database/migrations/2022_03_04_141328_create_reported_users_table.php
+++ b/database/migrations/2022_03_04_141328_create_reported_users_table.php
@@ -22,6 +22,15 @@ class CreateReportedUsersTable extends Migration
             $table->string('reason');
             $table->string('conversation_id')->nullable();
         });
+        
+        Schema::table('reported_users', function (Blueprint $table){
+            $table->foreign('reported_user_id')
+                ->references('id')->on('users')
+                ->onDelete('cascade');
+            $table->foreign('reported_by_user_id')
+                ->references('id')->on('users')
+                ->onDelete('cascade');
+        });
     }
 
     /**


### PR DESCRIPTION
Okay listen I know I'm not supposed to change migrations, but before going live I'll fix all migrations anyway, and we keep wiping the database all the time anyway too. So suck it up. I've added a foreign id to the reported users, with a cascade, as well as on the blocklist (it was missing there as well)
Whenever you next to a full wipe and remigration it'll be fixed, until then nothing has changed so it's not necessary just now.

Resolves #269 