### PR TITLE
Changed error message on thrown error

### DIFF
--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -30,7 +30,7 @@ class GroupsController extends Controller
             $allGroups = GroupResource::collection(Group::where('is_public', true)->get());
             return new JsonResponse(['groups' => ['my' => $myGroups, 'all' => $allGroups]]);
         }
-        return new JsonResponse(['message' => ['error' => "Only 'all', 'my' and 'dashboard' are permitted."]], Response::HTTP_FORBIDDEN);
+        return new JsonResponse(['message' => "Only 'all', 'my' and 'dashboard' are permitted."], Response::HTTP_FORBIDDEN);
     }
 
     public function store(StoreGroupRequest $request): JsonResponse{
@@ -69,11 +69,11 @@ class GroupsController extends Controller
         $user = Auth::user();
         $users = $group->users();
         if (!$user->groups()->find($group))
-            return new JsonResponse(['message' => ['error' =>"You are not a member of the group you are trying to leave."]], Response::HTTP_BAD_REQUEST);
+            return new JsonResponse(['message' => "You are not a member of the group you are trying to leave."], Response::HTTP_BAD_REQUEST);
         if ($users->count() == 1)
-            return new JsonResponse(['message' => ['error' =>"You can't leave a group you are the only member of, please delete instead."]], Response::HTTP_BAD_REQUEST);
+            return new JsonResponse(['message' => "You can't leave a group you are the only member of, please delete instead."], Response::HTTP_BAD_REQUEST);
         if ($group->isAdminById($user->id))
-            return new JsonResponse(['message' => ['error' => "You cannot leave a group where you are an admin."]], Response::HTTP_BAD_REQUEST);
+            return new JsonResponse(['message' => "You cannot leave a group where you are an admin."], Response::HTTP_BAD_REQUEST);
         $users->detach($user);
         ActionTrackingHandler::handleAction($request, 'LEAVE_GROUP', $user->username.' left group '.$group->name);
         return new JsonResponse(['message' => ['success' => "You have successfully left the group \"{$group->name}\"."]], Response::HTTP_OK);

--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -27,7 +27,7 @@ class MessageController extends Controller
         /** @var User */
         $user = Auth::user();
         if($user->isBlocked($request['recipient_id'])){
-            return new JsonResponse(['message' => ['error' => 'You are unable to send messages to this user.']], Response::HTTP_UNPROCESSABLE_ENTITY);
+            return new JsonResponse(['message' => 'You are unable to send messages to this user.'], Response::HTTP_UNPROCESSABLE_ENTITY);
         }
         $validated = $request->validated();
         $validated['sender_id'] = $user->id;

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -36,7 +36,7 @@ class NotificationController extends Controller
             return new JsonResponse(['message' => ['success' => 'Notification deleted.'], 'data' => NotificationResource::collection(Auth::user()->notifications)], Response::HTTP_OK); 
         } else {
             ActionTrackingHandler::handleAction($request, 'DELETE_NOTIFICATION', 'Deleting notification', 'Not authorized');
-            return new JsonResponse(['errors' => ['error' => 'You are not authorized to do this.']], Response::HTTP_FORBIDDEN); 
+            return new JsonResponse(['message' => 'You are not authorized to do this.'], Response::HTTP_FORBIDDEN); 
         }
     }
 

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -52,7 +52,7 @@ class TaskController extends Controller
             return new JsonResponse(['message' => ['info' => "Task deleted."], 'data' => $taskLists], Response::HTTP_OK);
         } else {
             ActionTrackingHandler::handleAction($request, 'DELETE_TASK', 'Deleting task named: '.$task->name, 'Not authorized');
-            return new JsonResponse(['errors' => ['error' => "You are not authorized to delete this task"]], Response::HTTP_FORBIDDEN);
+            return new JsonResponse(['message' => "You are not authorized to delete this task"], Response::HTTP_FORBIDDEN);
         }
     }
 
@@ -82,7 +82,7 @@ class TaskController extends Controller
             }
         } else {
             ActionTrackingHandler::handleAction($request, 'COMPLETE_TASK', 'Completing task named: '.$task->name, 'Not authorized');
-            return new JsonResponse(['errors' => ['error' => "You are not authorized to complete this task"]], Response::HTTP_FORBIDDEN);
+            return new JsonResponse(['message' => "You are not authorized to complete this task"], Response::HTTP_FORBIDDEN);
         }
     }
 

--- a/app/Http/Controllers/TaskListController.php
+++ b/app/Http/Controllers/TaskListController.php
@@ -61,7 +61,7 @@ class TaskListController extends Controller
             return new JsonResponse(['message' => ['success' => "Task list deleted."], 'data' => $taskLists], Response::HTTP_OK);
         } else {
             ActionTrackingHandler::handleAction($request, 'DELETE_TASK_LIST', 'Deleting tasklist named: '.$tasklist->name, 'Not authorized');
-            return new JsonResponse(['errors' => ['error' => "You are not authorized to delete this task list"]], Response::HTTP_FORBIDDEN);
+            return new JsonResponse(['message' => "You are not authorized to delete this task list"], Response::HTTP_FORBIDDEN);
         }
     }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -45,7 +45,7 @@ class UserController extends Controller
      */
     public function isAdmin() {
         if(!Auth::user()->admin){
-            return new JsonResponse(['errors' => ['error' => "You are not admin."]], Response::HTTP_UNAUTHORIZED);
+            return new JsonResponse(['message' => "You are not admin."], Response::HTTP_UNAUTHORIZED);
         }
     }
 

--- a/resources/js/router/router.js
+++ b/resources/js/router/router.js
@@ -21,8 +21,6 @@ import Feedback from '../pages/Feedback.vue';
 import {useUserStore} from '../store/userStore';
 // import Test from '../pages/Test.vue';
 
-// Vue.use(VueRouter);
-
 let routes = [
     {
         path: '/',
@@ -113,7 +111,6 @@ router.beforeEach((to, from, next) => {
     const mainStore = useMainStore();
     const userStore = useUserStore();
     mainStore.clearErrors();
-    console.log(userStore.user);
 
     if (to.path == '/' && userStore.authenticated) {
         return next({path: '/dashboard'});


### PR DESCRIPTION
Resolves #332 
Due to the structure of errors and messages in validation, the interceptor accepts error toasts as follows:
['message' => 'Toast message']. It is already wrapped in an error, so it no longer needs the key 'error', nor does it need to be wrapped in another array.