### PR TITLE
Added Object.assign to copy props, fixed bugs

### DIFF
--- a/resources/js/components/modals/EditAchievement.vue
+++ b/resources/js/components/modals/EditAchievement.vue
@@ -72,7 +72,7 @@ const props = defineProps({
 const emit = defineEmits(['close']);
 
 onMounted(() => {
-    achievementToEdit.value = props.achievement;
+    achievementToEdit.value = Object.assign({}, props.achievement);
 });
 
 /** @type {import('resources/types/achievement').Achievement} */

--- a/resources/js/components/modals/EditBugReport.vue
+++ b/resources/js/components/modals/EditBugReport.vue
@@ -58,7 +58,7 @@
 
 <script setup>
 import BaseFormError from '../BaseFormError.vue';
-import {shallowRef, onMounted, ref} from 'vue';
+import {onMounted, ref} from 'vue';
 import {BUG_TYPES, BUG_SEVERITY, BUG_STATUS} from '../../constants/bugConstants';
 import {useAdminStore} from '/js/store/adminStore';
 import {useMessageStore} from '/js/store/messageStore';
@@ -74,7 +74,7 @@ const props = defineProps({
 const emit = defineEmits(['close']);
 
 onMounted(() => {
-    bugReportToEdit.value = shallowRef(props.bugReport).value;
+    bugReportToEdit.value = Object.assign({}, props.bugReport);
 });
 
 const bugReportToEdit = ref({});

--- a/resources/js/components/modals/EditRewardObjectName.vue
+++ b/resources/js/components/modals/EditRewardObjectName.vue
@@ -21,10 +21,11 @@
 
 <script setup>
 import BaseFormError from '../BaseFormError.vue';
-import {shallowRef, onMounted, ref, computed} from 'vue';
+import {onMounted, ref, computed} from 'vue';
 import {useI18n} from 'vue-i18n'
 const {t} = useI18n() // use as global scope
 import {useRewardStore} from '/js/store/rewardStore';
+const rewardStore = useRewardStore();
 
 const props = defineProps({
     rewardObj: {
@@ -38,13 +39,13 @@ const props = defineProps({
 });
 const emit = defineEmits(['close']);
 
-onMounted(() => props.rewardObj ? editedRewardObj.value = shallowRef(props.rewardObj) : editedRewardObj.value = {});
+onMounted(() => editedRewardObj.value = props.rewardObj ? Object.assign({}, props.rewardObj) : {});
 
 const editedRewardObj = ref({});
 
 async function updateRewardObj() {
     editedRewardObj.value.type = props.type;
-    await useRewardStore.updateRewardObjName(editedRewardObj);
+    await rewardStore.updateRewardObjName(editedRewardObj.value);
     close();
 }
 function close() {

--- a/resources/js/components/modals/EditTask.vue
+++ b/resources/js/components/modals/EditTask.vue
@@ -73,7 +73,7 @@ const editedTask = ref({});
 const taskTypes = TASK_TYPES;
 const repeatables = REPEATABLES;
 
-const prop = defineProps({
+const props = defineProps({
     task: {
         /** @type {import('../../../types/task').Task} */
         type: Object,
@@ -82,14 +82,14 @@ const prop = defineProps({
 });
 const emit = defineEmits(['close']);
 onMounted(() => {
-    editedTask.value = prop.task ? prop.task.value : {};
+    editedTask.value = props.task ? Object.assign({}, props.task.value) : {};
 });
 
 const taskStore = useTaskStore();
 
 async function updateTask() {
-    await taskStore.updateTask(editedTask);
-    this.close();
+    await taskStore.updateTask(editedTask.value);
+    close();
 }
 function close() {
     emit('close');

--- a/resources/js/components/modals/EditTaskList.vue
+++ b/resources/js/components/modals/EditTaskList.vue
@@ -22,7 +22,6 @@
 <script setup>
 import {onMounted, ref} from 'vue';
 import BaseFormError from '../BaseFormError.vue';
-import {shallowRef} from 'vue';
 import {useTaskStore} from '/js/store/taskStore';
 const taskStore = useTaskStore();
 
@@ -35,7 +34,7 @@ const props = defineProps({
 });
 const emit = defineEmits(['close']);
 
-onMounted(() => editedTaskList.value = props.taskList ? shallowRef(props.taskList).value : {});
+onMounted(() => editedTaskList.value = props.taskList ? Object.assign({}, props.taskList) : {});
 
 /** @type {import('../../../types/task').TaskList} */
 const editedTaskList = ref({});

--- a/resources/js/components/small/TaskList.vue
+++ b/resources/js/components/small/TaskList.vue
@@ -23,7 +23,6 @@
             <slot>
                 <template v-for="(task, index) in taskList.tasks" :key="task.id">
                     <Task 
-                       
                         :task="task" 
                         :class="taskClass(index)"
                         v-on:newTask="openNewTask"


### PR DESCRIPTION
Resolves #328 
Used Object.assign to copy props, rather than wrapping them in another ref. Encountered a few bugs related to these issues and fixed them, mainly related to wrapped variabled.