### PR TITLE
Bug/301 hot reloading groups

### DIFF
--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Models\Groups_Users;
 use App\Http\Requests\StoreGroupRequest;
 use App\Http\Requests\DeleteGroupRequest;
+use App\Http\Requests\UpdateGroupsRequest;
 use App\Http\Requests\JoinGroupRequest;
 use App\Http\Requests\LeaveGroupRequest;
 use App\Http\Resources\GroupResource;
@@ -77,5 +78,14 @@ class GroupsController extends Controller
         $users->detach($user);
         ActionTrackingHandler::handleAction($request, 'LEAVE_GROUP', $user->username.' left group '.$group->name);
         return new JsonResponse(['message' => ['success' => "You have successfully left the group \"{$group->name}\"."]], Response::HTTP_OK);
+    }
+
+    public function update(Group $group, UpdateGroupsRequest $request) {
+        if (!$group->isAdminById(Auth::user()->id))
+            return new JsonResponse(['message' => "You are not an admin of the group you are trying to update."], Response::HTTP_BAD_REQUEST);
+        $validated = $request->validated();
+        $group->update($validated);
+        $myGroups = MyGroupResource::collection(Auth::user()->groups);
+        return new JsonResponse(['message' => ['success' => ['You have updated the group.']], 'groups' => ['my' => $myGroups]], Response::HTTP_OK);
     }
 }

--- a/app/Http/Requests/UpdateGroupsRequest.php
+++ b/app/Http/Requests/UpdateGroupsRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateGroupsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return Auth::user(); 
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'nullable|string',
+            'description' => 'nullable|string',
+            'is_public' => 'nullable|boolean',
+        ];
+    }
+}

--- a/resources/assets/scss/app.scss
+++ b/resources/assets/scss/app.scss
@@ -20,6 +20,9 @@ body {
 p {
     margin-left:5px;
 }
+label, b {
+    font-weight: 500;
+}
 
 .footer {
     background-color: $background-darker;

--- a/resources/js/components/bootstrap/BTable.vue
+++ b/resources/js/components/bootstrap/BTable.vue
@@ -16,7 +16,7 @@
         </thead>
         <tbody>
             <tr v-for="(item, index) in sortedItems" :key="index">
-                <td v-for="(field, index) in fields" :key="index">
+                <td v-for="(field, idx) in fields" :key="idx">
                     <slot v-bind="{item, index}" :name="field.key">
                         {{item[field.key]}}
                     </slot>

--- a/resources/js/components/small/Editable.vue
+++ b/resources/js/components/small/Editable.vue
@@ -1,0 +1,90 @@
+<template>
+    <div>
+        <div v-if="!edit">
+            {{item}}
+            <Tooltip :text="$t('edit')">
+                <FaIcon 
+                    :id="'edit-item-' + index"
+                    :icon="['far', 'pen-to-square']"
+                    class="icon small"
+                    @click="edit = true" />
+            </Tooltip>
+        </div>
+        <div v-else>
+            <input
+                v-if="props.type == 'input'"
+                :id="name"
+                v-model="itemToEdit"
+                :name="name" />
+            <textarea
+                v-if="props.type == 'textarea'"
+                :id="name"
+                v-model="itemToEdit"
+                :name="name"
+                :rows="rows" />
+            <BaseFormError :name="name" /> 
+
+            <Tooltip :text="$t('save')">
+                <FaIcon 
+                    :id="'save-' + index"
+                    :icon="['far', 'square-check']"
+                    class="icon small green"
+                    @click="save" />
+            </Tooltip>
+
+            <Tooltip :text="$t('cancel')">
+                <FaIcon 
+                    :id="'cancel-' + index"
+                    :icon="['far', 'rectangle-xmark']"
+                    class="icon small red"
+                    @click="cancel" />
+            </Tooltip>
+        </div>
+    </div>    
+</template>
+
+<script setup>
+import {onMounted, ref} from 'vue';
+const props = defineProps({
+    item: {
+        type: String,
+        required: true,
+    },
+    index: {
+        type: Number,
+        required: true,
+    },
+    name: {
+        type: String,
+        required: true,
+    },
+    type: {
+        type: String,
+        required: false,
+        default: 'input',
+    },
+    rows: {
+        type: Number,
+        required: false,
+        default: 3,
+    },
+});
+const emit = defineEmits(['save']);
+
+const edit = ref(false);
+const itemToEdit = ref('');
+
+onMounted(() => setValue());
+
+function save() {
+    emit('save', {[props.name]: itemToEdit.value});
+    cancel();
+}
+function cancel() {
+    setValue();
+    edit.value = false;
+}
+function setValue() {
+    itemToEdit.value = props.item
+}
+</script>

--- a/resources/js/components/small/EditableTextarea.vue
+++ b/resources/js/components/small/EditableTextarea.vue
@@ -1,0 +1,82 @@
+<template>
+    <div>
+        <div v-if="!edit">
+            {{item}}
+            <Tooltip :text="$t('edit')">
+                <FaIcon 
+                    :id="'edit-item-' + index"
+                    :icon="['far', 'pen-to-square']"
+                    class="icon small"
+                    @click="edit = true" />
+            </Tooltip>
+        </div>
+        <div v-else>
+            <textarea
+                :id="name"
+                v-model="itemToEdit"
+                :name="name"
+                :rows="rows" />
+            <BaseFormError :name="name" /> 
+
+            <Tooltip :text="$t('save')">
+                <FaIcon 
+                    :id="'save-' + index"
+                    :icon="['far', 'square-check']"
+                    class="icon small green"
+                    @click="save" />
+            </Tooltip>
+
+            <Tooltip :text="$t('cancel')">
+                <FaIcon 
+                    :id="'cancel-' + index"
+                    :icon="['far', 'rectangle-x-mark']"
+                    class="icon small red"
+                    @click="cancel" />
+            </Tooltip>
+        </div>
+    </div>    
+</template>
+
+<script>
+import BaseFormError from '../BaseFormError.vue';
+export default {
+    components: {BaseFormError},
+    props: {
+        item: {
+            type: String,
+            required: true,
+        },
+        index: {
+            type: Number,
+            required: true,
+        },
+        name: {
+            type: String,
+            required: true,
+        },
+        rows: {
+            type: Number,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            edit: false,
+            itemToEdit: null,
+        }
+    },
+    mounted() {
+        this.itemToEdit = this.item;
+    },
+    methods: {
+        save() {
+            this.$emit('save', {[this.name]: this.itemToEdit});
+            this.cancel();
+        },
+        cancel() {
+            this.itemToEdit = this.item;
+            this.edit = false;
+        },
+    },
+}
+</script>

--- a/resources/js/components/tabs/social/Groups.vue
+++ b/resources/js/components/tabs/social/Groups.vue
@@ -90,8 +90,6 @@ function closeCreateGroup() {
     showCreateGroupModal.value = false;
 }
 function showGroupsDetails(group) {
-    console.log(group);
-    console.log(myGroups.value[group]);
     groupDetailsItem.value = group;
     groupDetailsTitle.value = group.name;
     showGroupDetailsModal.value = true;
@@ -106,9 +104,16 @@ watch(
             chosenGroups.value = myGroups.value;
         else if (chosen.value == 'ALL')
             chosenGroups.value = allGroups.value;
-        console.log(groupDetailsItem.value)
+        reloadGroupDetailsItem();
     },
 );
+function reloadGroupDetailsItem() { 
+    if (Object.keys(chosenGroups.value).length === 0) return;
+    const currentItem = groupDetailsItem.value;
+    const reloadedGroup = chosenGroups.value.find(item => item.id == currentItem.id);
+    groupDetailsItem.value = reloadedGroup;
+    groupDetailsTitle.value = reloadedGroup.name;
+}
 </script>
 
 <style lang="scss" scoped>

--- a/resources/js/components/tabs/social/Groups.vue
+++ b/resources/js/components/tabs/social/Groups.vue
@@ -34,7 +34,7 @@
 import BTable from '../../bootstrap/BTable.vue';
 import CreateGroup from './components/CreateGroup.vue'
 import GroupDetails from './components/GroupDetails.vue';
-import {computed, ref, onMounted, watch} from 'vue';
+import {computed, ref, onMounted} from 'vue';
 import Loading from '../../Loading.vue';
 import {ALL_GROUP_FIELDS, MY_GROUP_FIELDS} from '../../../constants/groupConstants.js';
 import {useGroupStore} from '@/store/groupStore';
@@ -45,43 +45,44 @@ const groupStore = useGroupStore();
 const userStore = useUserStore();
 const mainStore = useMainStore();
 
-const myGroups = computed(() => groupStore.myGroups);
-const allGroups = computed(() => groupStore.allGroups);
 const user = computed(() => userStore.user);
-const filteredAllGroups = computed(() => {
-    return chosenGroups.value.filter(group =>
-        group.name.toLowerCase().includes(search.value.toLowerCase()));
-});
+const groupFields = ref({});
+
+const loading = ref(true);
 onMounted(() => {
     load();
 });
-const search = ref('');
-const chosenGroups = ref({});
-const loading = ref(true);
-const groupFields = ref({});
-const chosen = ref('');
-const showCreateGroupModal = ref(false);
-const showGroupDetailsModal = ref(false);
-const groupDetailsItem = ref({});
-const groupDetailsTitle = ref('');
-
 async function load() {
     await groupStore.fetchGroupsDashboard();
-    chosenGroups.value = myGroups.value;
     groupFields.value = MY_GROUP_FIELDS;
     chosen.value = 'MY';
     loading.value = false;
 }
+
+const search = ref('');
+const filteredAllGroups = computed(() => {
+    return chosenGroups.value.filter(group =>
+        group.name.toLowerCase().includes(search.value.toLowerCase()));
+});
+
+const myGroups = computed(() => groupStore.myGroups);
+const allGroups = computed(() => groupStore.allGroups);
+const chosen = ref('');
+const chosenGroups = computed(() => {
+    if (chosen.value == 'MY') return myGroups.value;
+    if (chosen.value == 'ALL') return allGroups.value;
+    return {};
+});
 function showMyGroups() {
-    chosenGroups.value = myGroups.value;
     groupFields.value = MY_GROUP_FIELDS;
     chosen.value = 'MY';
 }
 function showAllGroups() {
-    chosenGroups.value = allGroups.value;
     groupFields.value = ALL_GROUP_FIELDS;
     chosen.value = 'ALL';
 }
+
+const showCreateGroupModal = ref(false);
 function createGroup() {
     mainStore.clearErrors();
     showCreateGroupModal.value = true;
@@ -89,30 +90,24 @@ function createGroup() {
 function closeCreateGroup() {
     showCreateGroupModal.value = false;
 }
+
+const groupDetailsItemId = ref(null);
+const groupDetailsItem = computed(() => {
+    if (!groupDetailsItemId.value) return ref({});
+    if (!chosenGroups.value) return ref({});
+    return chosenGroups.value.find(item => item.id == groupDetailsItemId.value);
+});
+const groupDetailsTitle = computed(() => {
+    if (!groupDetailsItem.value) return '';
+    return groupDetailsItem.value.name;
+});
+const showGroupDetailsModal = ref(false);
 function showGroupsDetails(group) {
-    groupDetailsItem.value = group;
-    groupDetailsTitle.value = group.name;
+    groupDetailsItemId.value = group.id;
     showGroupDetailsModal.value = true;
 }
 function closeGroupDetails() {
     showGroupDetailsModal.value = false;
-}
-watch(
-    () => groupStore.myGroups,
-    () => {
-        if (chosen.value == 'MY')
-            chosenGroups.value = myGroups.value;
-        else if (chosen.value == 'ALL')
-            chosenGroups.value = allGroups.value;
-        reloadGroupDetailsItem();
-    },
-);
-function reloadGroupDetailsItem() { 
-    if (Object.keys(chosenGroups.value).length === 0) return;
-    const currentItem = groupDetailsItem.value;
-    const reloadedGroup = chosenGroups.value.find(item => item.id == currentItem.id);
-    groupDetailsItem.value = reloadedGroup;
-    groupDetailsTitle.value = reloadedGroup.name;
 }
 </script>
 

--- a/resources/js/components/tabs/social/Groups.vue
+++ b/resources/js/components/tabs/social/Groups.vue
@@ -22,8 +22,8 @@
             <BModal :show="showCreateGroupModal" :footer="false" :title="$t('create-group')" @close="closeCreateGroup">
                 <CreateGroup @close="closeCreateGroup" @reloadGroups="load"/>
             </BModal>
-            <BModal class="l" :show="showGroupDetailsModal" :footer="false" 
-                    :title="groupDetailsTitle.value" @close="closeGroupDetails">
+            <BModal class="xl" :show="showGroupDetailsModal" :footer="false" 
+                    :title="groupDetailsTitle" @close="closeGroupDetails">
                 <GroupDetails :group="groupDetailsItem" :user="user" @close="closeGroupDetails" @reloadGroups="load" />
             </BModal>
         </div>
@@ -32,8 +32,8 @@
 
 <script setup>
 import BTable from '../../bootstrap/BTable.vue';
-import CreateGroup from '../../modals/CreateGroup.vue'
-import GroupDetails from '../../small/GroupDetails.vue';
+import CreateGroup from './components/CreateGroup.vue'
+import GroupDetails from './components/GroupDetails.vue';
 import {computed, ref, onMounted} from 'vue';
 import Loading from '../../Loading.vue';
 import {ALL_GROUP_FIELDS, MY_GROUP_FIELDS} from '../../../constants/groupConstants.js';

--- a/resources/js/components/tabs/social/Groups.vue
+++ b/resources/js/components/tabs/social/Groups.vue
@@ -19,13 +19,13 @@
                     {{ $t('no-groups-found') }}
                 </template>
             </BTable>
-            <BModal :show="showCreateGroupModal" :footer="false" :title="$t('create-group')" @close="closeCreateGroup">
+            <Modal :show="showCreateGroupModal" :footer="false" :title="$t('create-group')" @close="closeCreateGroup">
                 <CreateGroup @close="closeCreateGroup" @reloadGroups="load"/>
-            </BModal>
-            <BModal class="xl" :show="showGroupDetailsModal" :footer="false" 
-                    :title="groupDetailsTitle" @close="closeGroupDetails">
+            </Modal>
+            <Modal class="xl" :show="showGroupDetailsModal" :footer="false" 
+                   :title="groupDetailsTitle" @close="closeGroupDetails">
                 <GroupDetails :group="groupDetailsItem" :user="user" @close="closeGroupDetails" @reloadGroups="load" />
-            </BModal>
+            </Modal>
         </div>
     </div>
 </template>
@@ -34,10 +34,9 @@
 import BTable from '../../bootstrap/BTable.vue';
 import CreateGroup from './components/CreateGroup.vue'
 import GroupDetails from './components/GroupDetails.vue';
-import {computed, ref, onMounted} from 'vue';
+import {computed, ref, onMounted, watch} from 'vue';
 import Loading from '../../Loading.vue';
 import {ALL_GROUP_FIELDS, MY_GROUP_FIELDS} from '../../../constants/groupConstants.js';
-import BModal from '../../bootstrap/BModal.vue';
 import {useGroupStore} from '@/store/groupStore';
 import {useUserStore} from '@/store/userStore';
 import {useMainStore} from '@/store/store';
@@ -64,7 +63,7 @@ const chosen = ref('');
 const showCreateGroupModal = ref(false);
 const showGroupDetailsModal = ref(false);
 const groupDetailsItem = ref({});
-const groupDetailsTitle = ref({});
+const groupDetailsTitle = ref('');
 
 async function load() {
     await groupStore.fetchGroupsDashboard();
@@ -91,6 +90,8 @@ function closeCreateGroup() {
     showCreateGroupModal.value = false;
 }
 function showGroupsDetails(group) {
+    console.log(group);
+    console.log(myGroups.value[group]);
     groupDetailsItem.value = group;
     groupDetailsTitle.value = group.name;
     showGroupDetailsModal.value = true;
@@ -98,6 +99,16 @@ function showGroupsDetails(group) {
 function closeGroupDetails() {
     showGroupDetailsModal.value = false;
 }
+watch(
+    () => groupStore.myGroups,
+    () => {
+        if (chosen.value == 'MY')
+            chosenGroups.value = myGroups.value;
+        else if (chosen.value == 'ALL')
+            chosenGroups.value = allGroups.value;
+        console.log(groupDetailsItem.value)
+    },
+);
 </script>
 
 <style lang="scss" scoped>

--- a/resources/js/components/tabs/social/components/CreateGroup.vue
+++ b/resources/js/components/tabs/social/components/CreateGroup.vue
@@ -39,7 +39,7 @@
 
 <script setup>
 import {reactive} from 'vue';
-import BaseFormError from '../BaseFormError.vue';
+import BaseFormError from '../../../BaseFormError.vue';
 import {useGroupStore} from '@/store/groupStore.js';
 const groupStore = useGroupStore();
 

--- a/resources/js/components/tabs/social/components/GroupDetails.vue
+++ b/resources/js/components/tabs/social/components/GroupDetails.vue
@@ -1,43 +1,51 @@
 <template>
     <div class="details">
         <div class="row">
-            <div class="col-sm-2"><b>{{ $t('founded') }}:</b></div>
-            <div class="col">{{group.time_created}}</div>
-        </div>
-        <div class="row">
-            <div class="col-sm-2"><b>{{ $t('admin') }}:</b></div>
-            <div class="col">
-                <router-link :to="{ name: 'profile', params: { id: group.admin.id}}">
-                    {{group.admin.username}}
-                </router-link>
+            <div class="col-8">
+                <div class="row mb-1">
+                    <div class="col-2"><b>{{ $t('admin') }}: </b></div>
+                    <div class="col-4">
+                        <router-link :to="{ name: 'profile', params: { id: group.admin.id}}">
+                            {{group.admin.username}}
+                        </router-link>
+                    </div>
+                </div>
+                <div class="row mb-1">
+                    <div class="col-2"><b>{{ $t('founded') }}: </b></div>
+                    <div class="col-4">{{group.time_created}}</div>
+                </div>
+                <div class="row mb-1">
+                    <div class="col-2"><b>{{ $t('members') }}:</b></div>
+                    <div class="col-4">{{group.members.length}}</div>
+                </div>
             </div>
-        </div>
-        <div v-if="isJoinGroupVisible" class="row">
-            <div class="col">
-                <button type="button" @click="joinGroup()">{{$t('join-group')}}</button>
-            </div>
-        </div>
-        <div v-else class="row">
-            <div v-if="isUserAdmin" class="col">
-                <button type="button" @click="deleteGroup()">{{ $t('delete-group') }}</button>
-            </div>
-
-            <div v-else class="col">
-                <button type="button" @click="leaveGroup()">{{ $t('leave-group') }}</button>
-            </div>
-        </div>
-        <hr />
-        <div class="row">
-            <div class="col-sm-2"><b>{{group.members.length}} {{ $t('members') }}:</b></div>
-            <div class="col">
-                <div v-for="member in group.members" :key="member.id" class="row">
-                    <div class="col-sm-3">{{member.username}}</div>
-                    <div class="col-sm-2">{{member.rank}}</div>
-                    <div class="col-sm-5">Joined: {{member.joined}}</div>
+            <div class="col-3">
+                <div v-if="isJoinGroupVisible" class="row">
+                    <button type="button" @click="joinGroup()">{{$t('join-group')}}</button>
+                </div>
+                <div v-else class="row">
+                    <div v-if="isUserAdmin">
+                        <button type="button" @click="deleteGroup()">{{ $t('delete-group') }}</button>
+                    </div>
+                    <div v-else>
+                        <button type="button" @click="leaveGroup()">{{ $t('leave-group') }}</button>
+                    </div>
                 </div>
             </div>
         </div>
-        
+        <hr />
+        <div class="row ml-0">
+            <b class="mb-3">{{ $t('member-list') }}</b>
+        </div>
+        <div class="row">
+            <div class="col">
+                <div v-for="member in group.members" :key="member.id" class="row">
+                    <div class="col-2">{{member.username}}</div>
+                    <div class="col-2">{{member.rank}}</div>
+                    <div class="col-5">Joined: {{member.joined}}</div>
+                </div>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -92,6 +100,8 @@ async function leaveGroup() {
 
 <style lang="scss" scoped>
 .details{
+    // display: flex;
+    // flex-wrap: wrap;
     margin: 0px 15px 0px 15px;
 }
 </style>

--- a/resources/js/components/tabs/social/components/GroupDetails.vue
+++ b/resources/js/components/tabs/social/components/GroupDetails.vue
@@ -57,7 +57,7 @@
 </template>
 
 <script setup>
-import {computed, ref} from 'vue';
+import {computed, watch, ref} from 'vue';
 import ManageGroupModal from './ManageGroupModal.vue';
 import {useI18n} from 'vue-i18n'
 const {t} = useI18n() // use as global scope
@@ -75,6 +75,7 @@ const props = defineProps({
     },
 });
 
+console.log(props.group)
 const emit = defineEmits(['close', 'reloadGroups']);
 
 const isJoinGroupVisible = computed(() => {
@@ -112,6 +113,10 @@ function manageGroup() {
 function closeManageGroup() {
     showManageGroupModal.value = false;
 }
+watch(
+    () => props.group,
+    () => console.log('updated'),
+);
 </script>
 
 <style lang="scss" scoped>

--- a/resources/js/components/tabs/social/components/GroupDetails.vue
+++ b/resources/js/components/tabs/social/components/GroupDetails.vue
@@ -57,7 +57,7 @@
 </template>
 
 <script setup>
-import {computed, watch, ref} from 'vue';
+import {computed, ref} from 'vue';
 import ManageGroupModal from './ManageGroupModal.vue';
 import {useI18n} from 'vue-i18n'
 const {t} = useI18n() // use as global scope
@@ -75,10 +75,6 @@ const props = defineProps({
     },
 });
 
-const group = ref(props.group);
-// onMounted(() => group.value = props.group ? props.group : {});
-
-console.log(props.group)
 const emit = defineEmits(['close', 'reloadGroups']);
 
 const isJoinGroupVisible = computed(() => {
@@ -116,10 +112,6 @@ function manageGroup() {
 function closeManageGroup() {
     showManageGroupModal.value = false;
 }
-watch(
-    () => props.group,
-    () => console.log('updated'),
-);
 </script>
 
 <style lang="scss" scoped>

--- a/resources/js/components/tabs/social/components/GroupDetails.vue
+++ b/resources/js/components/tabs/social/components/GroupDetails.vue
@@ -57,7 +57,7 @@
 </template>
 
 <script setup>
-import {computed, watch, ref} from 'vue';
+import {computed, ref} from 'vue';
 import ManageGroupModal from './ManageGroupModal.vue';
 import {useI18n} from 'vue-i18n'
 const {t} = useI18n() // use as global scope
@@ -75,7 +75,6 @@ const props = defineProps({
     },
 });
 
-console.log(props.group)
 const emit = defineEmits(['close', 'reloadGroups']);
 
 const isJoinGroupVisible = computed(() => {
@@ -113,10 +112,6 @@ function manageGroup() {
 function closeManageGroup() {
     showManageGroupModal.value = false;
 }
-watch(
-    () => props.group,
-    () => console.log('updated'),
-);
 </script>
 
 <style lang="scss" scoped>

--- a/resources/js/components/tabs/social/components/GroupDetails.vue
+++ b/resources/js/components/tabs/social/components/GroupDetails.vue
@@ -89,3 +89,9 @@ async function leaveGroup() {
     emit('close');
 }
 </script>
+
+<style lang="scss" scoped>
+.details{
+    margin: 0px 15px 0px 15px;
+}
+</style>

--- a/resources/js/components/tabs/social/components/GroupDetails.vue
+++ b/resources/js/components/tabs/social/components/GroupDetails.vue
@@ -1,56 +1,64 @@
 <template>
-    <div class="details">
-        <div class="row">
-            <div class="col-8">
-                <div class="row mb-1">
-                    <div class="col-2"><b>{{ $t('admin') }}: </b></div>
-                    <div class="col-4">
-                        <router-link :to="{ name: 'profile', params: { id: group.admin.id}}">
-                            {{group.admin.username}}
-                        </router-link>
+    <div>
+        <div class="details">
+            <div class="row">
+                <div class="col-8">
+                    <div class="row mb-1">
+                        <div class="col-2"><b>{{ $t('admin') }}: </b></div>
+                        <div class="col-4">
+                            <router-link :to="{ name: 'profile', params: { id: group.admin.id}}">
+                                {{group.admin.username}}
+                            </router-link>
+                        </div>
+                    </div>
+                    <div class="row mb-1">
+                        <div class="col-2"><b>{{ $t('founded') }}: </b></div>
+                        <div class="col-4">{{group.time_created}}</div>
+                    </div>
+                    <div class="row mb-1">
+                        <div class="col-2"><b>{{ $t('members') }}:</b></div>
+                        <div class="col-4">{{group.members.length}}</div>
                     </div>
                 </div>
-                <div class="row mb-1">
-                    <div class="col-2"><b>{{ $t('founded') }}: </b></div>
-                    <div class="col-4">{{group.time_created}}</div>
-                </div>
-                <div class="row mb-1">
-                    <div class="col-2"><b>{{ $t('members') }}:</b></div>
-                    <div class="col-4">{{group.members.length}}</div>
+                <div class="col-3">
+                    <div v-if="isJoinGroupVisible" class="row">
+                        <button type="button" @click="joinGroup()">{{$t('join-group')}}</button>
+                    </div>
+                    <div v-else class="row">
+                        <div v-if="isUserAdmin">
+                            <button type="button" @click="deleteGroup()">{{ $t('delete-group') }}</button>
+                            <button type="button" @click="manageGroup()">{{ $t('manage-group') }}</button>
+                        </div>
+                        <div v-else>
+                            <button type="button" @click="leaveGroup()">{{ $t('leave-group') }}</button>
+                        </div>
+                    </div>
                 </div>
             </div>
-            <div class="col-3">
-                <div v-if="isJoinGroupVisible" class="row">
-                    <button type="button" @click="joinGroup()">{{$t('join-group')}}</button>
-                </div>
-                <div v-else class="row">
-                    <div v-if="isUserAdmin">
-                        <button type="button" @click="deleteGroup()">{{ $t('delete-group') }}</button>
-                    </div>
-                    <div v-else>
-                        <button type="button" @click="leaveGroup()">{{ $t('leave-group') }}</button>
+            <hr />
+            <div class="row ml-0">
+                <b class="mb-3">{{ $t('member-list') }}</b>
+            </div>
+            <div class="row">
+                <div class="col">
+                    <div v-for="member in group.members" :key="member.id" class="row">
+                        <div class="col-2">{{member.username}}</div>
+                        <div class="col-2">{{member.rank}}</div>
+                        <div class="col-5">Joined: {{member.joined}}</div>
                     </div>
                 </div>
             </div>
         </div>
-        <hr />
-        <div class="row ml-0">
-            <b class="mb-3">{{ $t('member-list') }}</b>
-        </div>
-        <div class="row">
-            <div class="col">
-                <div v-for="member in group.members" :key="member.id" class="row">
-                    <div class="col-2">{{member.username}}</div>
-                    <div class="col-2">{{member.rank}}</div>
-                    <div class="col-5">Joined: {{member.joined}}</div>
-                </div>
-            </div>
-        </div>
+        <Modal class="xl" :show="showManageGroupModal" :footer="false" 
+               :title="group.name" @close="closeManageGroup">
+            <ManageGroupModal :group="group" />
+        </Modal>
     </div>
 </template>
 
 <script setup>
-import {computed} from 'vue';
+import {computed, watch, ref} from 'vue';
+import ManageGroupModal from './ManageGroupModal.vue';
 import {useI18n} from 'vue-i18n'
 const {t} = useI18n() // use as global scope
 import {useGroupStore} from '/js/store/groupStore';
@@ -66,6 +74,11 @@ const props = defineProps({
         required: true,
     },
 });
+
+const group = ref(props.group);
+// onMounted(() => group.value = props.group ? props.group : {});
+
+console.log(props.group)
 const emit = defineEmits(['close', 'reloadGroups']);
 
 const isJoinGroupVisible = computed(() => {
@@ -75,6 +88,7 @@ const isJoinGroupVisible = computed(() => {
     }
     return $isVisible;
 });
+const showManageGroupModal = ref(false);
 const isUserAdmin = computed(() => {
     return props.group.admin.id == props.user.id;
 });
@@ -96,6 +110,16 @@ async function leaveGroup() {
     emit('reloadGroups');
     emit('close');
 }
+function manageGroup() {
+    showManageGroupModal.value = true;
+}
+function closeManageGroup() {
+    showManageGroupModal.value = false;
+}
+watch(
+    () => props.group,
+    () => console.log('updated'),
+);
 </script>
 
 <style lang="scss" scoped>

--- a/resources/js/components/tabs/social/components/ManageGroupModal.vue
+++ b/resources/js/components/tabs/social/components/ManageGroupModal.vue
@@ -1,0 +1,89 @@
+<template>
+    <div>
+        <h5>{{ group.name }}</h5>
+        <div v-if="group">
+            <form @submit.prevent="editGroup">
+                <label for="edit-name-comp">Name</label>
+                <Editable 
+                    id="edit-name-comp" 
+                    :key="group.name" 
+                    class="ml-1 mb-2"
+                    :item="group.name" 
+                    :index="1" 
+                    :name="'name'" 
+                    @save="save" />
+                
+                <label for="edit-description-comp">Description</label>
+                <Editable 
+                    id="edit-description-comp"
+                    :key="group.description"
+                    class="ml-1 mb-2"
+                    :item="group.description" 
+                    :index="2" 
+                    :name="'description'" 
+                    :type="'textarea'"
+                    :rows="3" 
+                    @save="save" />
+
+                <button class="m-1" @click="togglePublic">
+                    {{group.is_public ? 'Set to private' : 'Make public' }}
+                </button>
+                <!-- TODO turn this into a 'turn off button' -->
+            </form>
+        </div>
+        <!-- Manage users -->
+        <div>
+            <label for="">Members</label>
+            <div v-for="member in group.members" :key="member.id" class="d-flex hover">
+                <!-- TODO make a table -->
+                {{member.username}}
+                <span class="ml-auto">
+                    <Tooltip :text="$t('send-message')">
+                        <FaIcon 
+                            icon="envelope"
+                            class="icon small"
+                            @click="sendMessage" />
+                    </Tooltip>
+                    <Tooltip :text="$t('kick')">
+                        <FaIcon 
+                            :icon="['far', 'rectangle-xmark']"
+                            class="icon small red"
+                            @click="kick" />
+                    </Tooltip>
+
+                </span>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import Editable from '../../../small/Editable.vue';
+import {useGroupStore} from '/js/store/groupStore';
+const groupStore = useGroupStore();
+
+const props = defineProps({
+    group: {
+        type: Object,
+        required: true,
+    },
+});
+console.log(props.group);
+function save(item) {
+    item.id = props.group.id;
+    groupStore.updateGroup(item);
+}
+function togglePublic() {
+    const group = {};
+    group.is_public = !props.group.is_public;
+    group.id = props.group.id;
+    groupStore.updateGroup(group);
+}
+
+function kick() {
+    console.log('kick');
+}
+function sendMessage() {
+    console.log('message');
+}
+</script>

--- a/resources/js/components/tabs/social/components/ManageGroupModal.vue
+++ b/resources/js/components/tabs/social/components/ManageGroupModal.vue
@@ -1,6 +1,5 @@
 <template>
     <div>
-        <h5>{{ group.name }}</h5>
         <div v-if="group">
             <form @submit.prevent="editGroup">
                 <label for="edit-name-comp">Name</label>
@@ -68,7 +67,6 @@ const props = defineProps({
         required: true,
     },
 });
-console.log(props.group);
 function save(item) {
     item.id = props.group.id;
     groupStore.updateGroup(item);

--- a/resources/js/pages/Social.vue
+++ b/resources/js/pages/Social.vue
@@ -15,7 +15,7 @@
             </button>
         </div>
         <KeepAlive class="col-10">
-            <component :is="currentTabComponent" />
+            <component :is="currentTabComponent" :key="activeComponent.value" />
         </KeepAlive>
     </div>
 </template>

--- a/resources/js/store/groupStore.js
+++ b/resources/js/store/groupStore.js
@@ -35,5 +35,9 @@ export const useGroupStore = defineStore('group', {
         async leaveGroup(group) {
             await axios.post(`/groups/leave/${group.id}`);
         },
+        async updateGroup(group) {
+            const {data} = await axios.put(`/groups/edit/${group.id}`, group);
+            this.myGroups = data.groups.my;
+        },
     },
 });

--- a/resources/js/store/groupStore.js
+++ b/resources/js/store/groupStore.js
@@ -7,6 +7,7 @@ export const useGroupStore = defineStore('group', {
         return {
             myGroups: [],
             allGroups: [],
+            groupToManage: {},
         }
     },
     actions: {
@@ -38,6 +39,9 @@ export const useGroupStore = defineStore('group', {
         async updateGroup(group) {
             const {data} = await axios.put(`/groups/edit/${group.id}`, group);
             this.myGroups = data.groups.my;
+        },
+        setGroupToManage(group) {
+            this.groupToManage = group;
         },
     },
 });

--- a/resources/js/store/modules/groupsStore.js
+++ b/resources/js/store/modules/groupsStore.js
@@ -52,19 +52,26 @@ export default {
             return axios.delete(`/groups/${group.id}`).then(response => {
                 commit('addToast', response.data.message, {root:true});
                 return Promise.resolve();
-            })
+            });
         },
         joinGroup: ({commit}, group) => {
             return axios.post(`/groups/join/${group.id}`).then(response => {
                 commit('addToast', response.data.message, {root:true});
                 return Promise.resolve();
-            })
+            });
         },
         leaveGroup: ({commit}, group) => {
             return axios.post(`/groups/leave/${group.id}`).then(response => {
                 commit('addToast', response.data.message, {root:true});
                 return Promise.resolve();
-            })
+            });
+        },
+        updateGroup: ({commit, dispatch}, group) => {
+            return axios.put(`/groups/edit/${group.id}`, group).then(response => {
+                commit('setMyGroups', response.data.groups.my);
+                dispatch('sendToasts', response.data.message, {root:true});
+                return Promise.resolve();
+            });
         },
 
 

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -228,6 +228,7 @@
     "add-level": "Add level",
     "points": "Points",
     "search-by-level": "Search by level",
+    "manage-group": "Manage group",
     
     "exp-points": "Experience points",
     "char-exp-gain": "Character XP gain",
@@ -242,6 +243,8 @@
     "submit": "Submit",
     "delete": "Delete",
     "confirm": "Confirm",
+    "save": "Save",
+    "edit": "Edit",
 
     "welcome": "Welcome",
     "little-more": "Just a little more",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -206,6 +206,7 @@
     "close-group-button": "Close",
     "leave-group": "Leave group",
     "delete-group": "Delete group",
+    "member-list": "Member list",
     "show-details": "Show details",
     "delete-group-confirm": "Are you sure you want to delete the group {group}?",
     "leave-group-confirm": "Are you sure you want to leave the gorup {group}?",

--- a/routes/api.php
+++ b/routes/api.php
@@ -96,6 +96,8 @@ Route::group(['middleware' => ['auth']], function () {
     Route::resource('/groups', GroupsController::class)->only([
         'store', 'destroy', 'show',
     ]);
+    Route::put('/groups/edit/{group}', [GroupsController::class, 'update']);
+
     Route::put('/user/{blockedUser}/block', [MessageController::class, 'blockUser']);
 
     Route::get('/unread', [UserController::class, 'hasUnread']);


### PR DESCRIPTION
Toad fixed it.
The original prop that wasn't reloading was only assigned once, which is when you first open the modal. Now opening the modal only assigns the id of the chosen group. The assigned item is a computed property, so it gets changed when the reference changes.