### PR TITLE
Feature/271 admin see feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ Before launching the beta version of the site, the following things need to be f
 - [x] Tooltips on all buttons and otherwise unclear data
 - [ ] A tutorial or 'help what do I do here' button on every page
 # Users and interaction
-- [ ] Allowing users to manage their blocklist and search for friends to add
+- [x] Allowing users to manage their blocklist and search for friends to add
 - [ ] Allow a user to manage the group they are an admin of
 - [x] Fully allowing a user to manage their characters or villages (rename them, see their level)
 - [ ] Finished groups: invites to private groups, 
 # Admin and back-end
-- [ ] Admins able to view and respond to feedback
+- [x] Admins able to view and respond to feedback
 - [ ] Admins able to view reported users and perform action: message the user, ban the user
 - [ ] Tracking of logins (attempts) for security
 - [ ] Worked out good balancing of the rewards (experience points) to start off with, and plenty of levels to gain

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -92,10 +92,18 @@ class AdminController extends Controller
         return new AdminConversationResource(Conversation::where('conversation_id', $id)->first());
     }
 
+    /**
+     * Fetches all existing feedback and returns it in a Resource collection
+     * @return JsonResponse with FeedbackResource collection
+     */
     public function getFeedback() {
         return new JsonResponse(['feedback' => FeedbackResource::collection(Feedback::get())]);
     }
             
+    /**
+     * Toggles the feedback's archive column. True to false and vice versa. Returns the updated collection.
+     * @return JsonResponse with string and FeedbackResource collection
+     */
     public function toggleArchiveFeedback(Feedback $feedback) {
         $feedback->archived = !$feedback->archived;
         $feedback->save();

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -19,6 +19,8 @@ use App\Models\ExperiencePoint;
 use App\Http\Resources\BugReportResource;
 use App\Http\Resources\ReportedUserResource;
 use App\Http\Resources\AdminConversationResource;
+use App\Http\Resources\FeedbackResource;
+use App\Models\Feedback;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
@@ -89,4 +91,17 @@ class AdminController extends Controller
     public function getConversationById($id) {
         return new AdminConversationResource(Conversation::where('conversation_id', $id)->first());
     }
+
+    public function getFeedback() {
+        return new JsonResponse(['feedback' => FeedbackResource::collection(Feedback::get())]);
+    }
+            
+    public function toggleArchiveFeedback(Feedback $feedback) {
+        $feedback->archived = !$feedback->archived;
+        $feedback->save();
+        return new JsonResponse([
+            'message' => ['success' => $feedback->archived ? 'Feedback archived': 'Feedback unarchived'],
+            'feedback' => FeedbackResource::collection(Feedback::get())], 
+            Response::HTTP_OK);
+    }   
 }

--- a/app/Http/Resources/FeedbackResource.php
+++ b/app/Http/Resources/FeedbackResource.php
@@ -16,11 +16,14 @@ class FeedbackResource extends JsonResource
     public function toArray($request)
     {
         return [
+            'id' => $this->id,
+            'created_at' => $this->created_at->toDateTimeString(),
+            'updated_at' => $this->updated_at->toDateTimeString(),
             'type' => $this->type,
             'text' => $this->text,
             'email' => $this->email,
             'user' => new StrippedUserResource($this->user),
-
+            'archived' => !!$this->archived,
         ];
     }
 }

--- a/resources/js/constants/feedbackConstants.js
+++ b/resources/js/constants/feedbackConstants.js
@@ -7,9 +7,8 @@ export const FEEDBACK_TYPES = [
 
 export const FEEDBACK_FIELDS = [
     {
-        label: 'Created', 
-        key: 'created_at',
-        sortable: true,
+        label: 'Actions', 
+        key: 'actions',
     },
     {
         label: 'Type', 
@@ -21,11 +20,21 @@ export const FEEDBACK_FIELDS = [
         key: 'text',
     },
     {
+        label: 'User', 
+        key: 'user',
+    },
+    {
         label: 'Email', 
         key: 'email',
     },
     {
-        label: 'User', 
-        key: 'user',
+        label: 'Created', 
+        key: 'created_at',
+        sortable: true,
+    },
+    {
+        label: 'Archived', 
+        key: 'archived',
+        sortable: true,
     },
 ];

--- a/resources/js/constants/feedbackConstants.js
+++ b/resources/js/constants/feedbackConstants.js
@@ -4,3 +4,28 @@ export const FEEDBACK_TYPES = [
     {text: 'Question', value: 'QUESTION'},
     {text: 'Other', value: 'OTHER'},
 ];
+
+export const FEEDBACK_FIELDS = [
+    {
+        label: 'Created', 
+        key: 'created_at',
+        sortable: true,
+    },
+    {
+        label: 'Type', 
+        key: 'type',
+        sortable: true,
+    },
+    {
+        label: 'Text', 
+        key: 'text',
+    },
+    {
+        label: 'Email', 
+        key: 'email',
+    },
+    {
+        label: 'User', 
+        key: 'user',
+    },
+];

--- a/resources/js/icons.js
+++ b/resources/js/icons.js
@@ -21,7 +21,9 @@ import {
     faUserPlus,
     faSort,
     faMagnifyingGlass,
+    faLock,
     faLockOpen,
+    faBoxArchive,
 } from '@fortawesome/free-solid-svg-icons';
 library.add(
     faPenToSquare, 
@@ -41,5 +43,7 @@ library.add(
     faRectangleXmark,
     faSort,
     faMagnifyingGlass,
+    faLock,
     faLockOpen,
+    faBoxArchive,
 );

--- a/resources/js/pages/admin/AdminDashboard.vue
+++ b/resources/js/pages/admin/AdminDashboard.vue
@@ -33,6 +33,12 @@
                     @click="switchTab('ReportedUsers')">
                     {{$t('reported-users')}}
                 </button>
+                <button 
+                    :class="activeTab('Feedback')" 
+                    class="tab-item"
+                    @click="switchTab('Feedback')">
+                    {{$t('feedback')}}
+                </button>
             </div>
             <KeepAlive class="tab-content col-10">
                 <component :is="currentTabComponent" :key="activeComponent" />
@@ -48,6 +54,7 @@ import BugReportPanel from './tabs/BugReportPanel.vue';
 import SendNotifications from './tabs/SendNotifications.vue';
 import Balancing from './tabs/Balancing.vue';
 import ReportedUsers from './tabs/ReportedUsers.vue';
+import Feedback from './tabs/Feedback.vue';
 import {shallowRef, onMounted, ref} from 'vue';
 import {useAdminStore} from '/js/store/adminStore';
 

--- a/resources/js/pages/admin/AdminDashboard.vue
+++ b/resources/js/pages/admin/AdminDashboard.vue
@@ -41,7 +41,7 @@
                 </button>
             </div>
             <KeepAlive class="tab-content col-10">
-                <component :is="currentTabComponent" :key="activeComponent" />
+                <component :is="currentTabComponent" :key="tabKey" />
             </KeepAlive>
         </div>
     </div>
@@ -63,25 +63,32 @@ const adminStore = useAdminStore();
 
 onMounted(async() => {
     await adminStore.getAdminDashboard();
+    if (window.location.hash)
+        tabKey.value = window.location.hash.slice(1);
+    else 
+        tabKey.value = 'Achievements';
+    currentTabComponent.value = tabs[tabKey.value];
     loading.value = false;
 });
 
-const componentNames = {
+const tabs = {
     'Achievements': Achievements,
     'BugReportPanel': BugReportPanel,
     'SendNotifications': SendNotifications,
     'Balancing': Balancing,
     'ReportedUsers': ReportedUsers,
+    'Feedback': Feedback,
 }
-const activeComponent = ref('Achievements');
+const tabKey = ref('');
 
-const currentTabComponent = shallowRef(componentNames[activeComponent.value]);
-function activeTab(component) {
-    if (component == activeComponent.value) return 'active-tab';
+const currentTabComponent = shallowRef(tabs[0]);
+function activeTab(key) {
+    if (key == tabKey.value) return 'active-tab';
     return 'tab';
 }
-function switchTab(component) {
-    currentTabComponent.value = componentNames[component];
-    activeComponent.value = component;
+function switchTab(key) {
+    currentTabComponent.value = tabs[key];
+    tabKey.value = key;
+    window.location.hash = key;
 }
 </script>

--- a/resources/js/pages/admin/tabs/Feedback.vue
+++ b/resources/js/pages/admin/tabs/Feedback.vue
@@ -1,24 +1,84 @@
 <template>
     <div>
         <h3>{{ $t('feedback') }}</h3>
+        <button @click="archived = !archived">{{archived ? 'Hide archived' : 'Show archived'}}</button>
         <Table
-            :items="feedback"
+            :items="filteredFeedback"
             :fields="feedbackFields"
             :options="['table-striped', 'page-wide']"
-        />
+        >
+            <template #user="row">
+                <router-link v-if="row.item.user" :to="{ name: 'profile', params: { id: row.item.user.id}}">
+                    {{row.item.user.username}}
+                </router-link>
+            </template>
+            <template #actions="row">
+                <Tooltip v-if="!row.item.archived" :text="$t('archive')">
+                    <FaIcon 
+                        icon="lock"
+                        class="icon small red"
+                        @click="toggleArchiveFeedback(row.item.id)" />
+                </Tooltip>
+                <Tooltip v-if="row.item.archived" :text="$t('unarchive')">
+                    <FaIcon 
+                        icon="lock-open"
+                        class="icon small green"
+                        @click="toggleArchiveFeedback(row.item.id)" />
+                </Tooltip>
+                <Tooltip :text="$t('message-user')">
+                    <FaIcon 
+                        v-if="row.item.user"
+                        icon="envelope"
+                        class="icon small"
+                        @click="sendMessageToUser(row.item.user)" />
+                </Tooltip>
+            </template>
+            <template #archived="row">
+                {{row.item.archived ? row.item.updated_at : ''}}
+            </template>
+        </Table>
+        <Modal 
+            :show="showSendMessageModal" 
+            :footer="false" 
+            :header="false"
+            @close="closeSendMessageModal">
+            <SendMessage :user="userToMessage" @close="closeSendMessageModal"/>
+        </Modal>
     </div>
 </template>
 
 <script setup>
-import {ref, onMounted} from 'vue';
+import {ref, onMounted, computed} from 'vue';
+import Table from '/js/components/global/Table.vue';
+import SendMessage from '/js/pages/messages/components/SendMessage.vue';
 import {FEEDBACK_FIELDS} from '/js/constants/feedbackConstants.js';
 import {useAdminStore} from '/js/store/adminStore';
 const adminStore = useAdminStore();
 
-onMounted(() => {
-    feedback.value = adminStore.getFeedback();
+onMounted(async() => {
+    feedback.value = await adminStore.getFeedback();
 })
 
 const feedback = ref([]);
+const filteredFeedback = computed(() => {
+    return archived.value ? feedback.value : feedback.value.filter(item => !item.archived);
+});
 const feedbackFields = ref(FEEDBACK_FIELDS);
+
+const showSendMessageModal = ref(false);
+const userToMessage = ref('');
+
+const archived = ref(false);
+
+function sendMessageToUser(user) {
+    userToMessage.value = user;
+    showSendMessageModal.value = true;
+}
+function closeSendMessageModal() {
+    showSendMessageModal.value = false;
+}
+
+async function toggleArchiveFeedback(feedbackId) {
+    feedback.value = await adminStore.toggleArchiveFeedback(feedbackId);
+}
 </script>

--- a/resources/js/pages/admin/tabs/Feedback.vue
+++ b/resources/js/pages/admin/tabs/Feedback.vue
@@ -1,0 +1,24 @@
+<template>
+    <div>
+        <h3>{{ $t('feedback') }}</h3>
+        <Table
+            :items="feedback"
+            :fields="feedbackFields"
+            :options="['table-striped', 'page-wide']"
+        />
+    </div>
+</template>
+
+<script setup>
+import {ref, onMounted} from 'vue';
+import {FEEDBACK_FIELDS} from '/js/constants/feedbackConstants.js';
+import {useAdminStore} from '/js/store/adminStore';
+const adminStore = useAdminStore();
+
+onMounted(() => {
+    feedback.value = adminStore.getFeedback();
+})
+
+const feedback = ref([]);
+const feedbackFields = ref(FEEDBACK_FIELDS);
+</script>

--- a/resources/js/pages/admin/tabs/Feedback.vue
+++ b/resources/js/pages/admin/tabs/Feedback.vue
@@ -70,6 +70,11 @@ const userToMessage = ref('');
 
 const archived = ref(false);
 
+/**
+ * Opens a modal to send a message to user, and sets the
+ * userToMessage to feed this user into the modal component.
+ * @param {import('resources/types/user').User} user
+ */
 function sendMessageToUser(user) {
     userToMessage.value = user;
     showSendMessageModal.value = true;
@@ -78,6 +83,10 @@ function closeSendMessageModal() {
     showSendMessageModal.value = false;
 }
 
+/**
+ * Sends a request to toggle the archived status of a feedback item
+ * @param {Number} feedbackId
+ */
 async function toggleArchiveFeedback(feedbackId) {
     feedback.value = await adminStore.toggleArchiveFeedback(feedbackId);
 }

--- a/resources/js/pages/settings/Settings.vue
+++ b/resources/js/pages/settings/Settings.vue
@@ -31,22 +31,31 @@
 import ProfileSettings from './tabs/ProfileSettings.vue';
 import RewardSettings from './tabs/RewardSettings.vue';
 import AccountSettings from './tabs/AccountSettings.vue';
-import {shallowRef, ref} from 'vue';
+import {shallowRef, ref, onMounted} from 'vue';
 
-const componentNames = {
+onMounted(async() => {
+    if (window.location.hash)
+        tabKey.value = window.location.hash.slice(1);
+    else 
+        tabKey.value = 'AccountSettings';
+    currentTabComponent.value = tabs[tabKey.value];
+});
+
+const tabs = {
     'AccountSettings': AccountSettings,
     'RewardSettings': RewardSettings,
     'ProfileSettings': ProfileSettings,
 }
-const activeComponent = ref('AccountSettings');
+const tabKey = ref('');
 
-const currentTabComponent = shallowRef(componentNames[activeComponent.value]);
-function activeTab(component) {
-    if (component == activeComponent.value) return 'active-tab';
+const currentTabComponent = shallowRef(tabs[0]);
+function activeTab(key) {
+    if (key == tabKey.value) return 'active-tab';
     return 'tab';
 }
-function switchTab(component) {
-    currentTabComponent.value = componentNames[component];
-    activeComponent.value = component;
+function switchTab(key) {
+    currentTabComponent.value = tabs[key];
+    tabKey.value = key;
+    window.location.hash = key;
 }
 </script>

--- a/resources/js/pages/social/Social.vue
+++ b/resources/js/pages/social/Social.vue
@@ -21,7 +21,7 @@
             </button>
         </div>
         <KeepAlive class="tab-content col-10">
-            <component :is="currentTabComponent" :key="activeComponent" />
+            <component :is="currentTabComponent" :key="tabKey" />
         </KeepAlive>
     </div>
 </template>
@@ -30,22 +30,31 @@
 import Groups from './tabs/Groups.vue';
 import Friends from './tabs/Friends.vue';
 import Blocklist from './tabs/Blocklist.vue';
-import {shallowRef, ref} from 'vue';
+import {shallowRef, ref, onMounted} from 'vue';
 
-const componentNames = {
+onMounted(async() => {
+    if (window.location.hash)
+        tabKey.value = window.location.hash.slice(1);
+    else 
+        tabKey.value = 'Groups';
+    currentTabComponent.value = tabs[tabKey.value];
+});
+
+const tabs = {
     'Groups': Groups,
     'Friends': Friends,
     'Blocklist': Blocklist,
 }
-const activeComponent = ref('Groups');
+const tabKey = ref('');
 
-const currentTabComponent = shallowRef(componentNames[activeComponent.value]);
-function activeTab(component) {
-    if (component == activeComponent.value) return 'active-tab';
+const currentTabComponent = shallowRef(tabs[0]);
+function activeTab(key) {
+    if (key == tabKey.value) return 'active-tab';
     return 'tab';
 }
-function switchTab(component) {
-    currentTabComponent.value = componentNames[component];
-    activeComponent.value = component;
+function switchTab(key) {
+    currentTabComponent.value = tabs[key];
+    tabKey.value = key;
+    window.location.hash = key;
 }
 </script>

--- a/resources/js/store/adminStore.js
+++ b/resources/js/store/adminStore.js
@@ -98,11 +98,18 @@ export const useAdminStore = defineStore('admin', {
             this.villageExpGain = data.data;
         },
         /**
-         * 
+         * @returns Array<import('resources/types/feedback').Feedback>
          */
         async getFeedback() {
-            //TODO
             const {data} = await axios.get('/admin/feedback');
+            return data.feedback;
+        },
+        /**
+         * @param {Number} id
+         * @returns Array<import('resources/types/feedback').Feedback>
+         */
+        async toggleArchiveFeedback(id) {
+            const {data} = await axios.post(`/admin/feedback/archive/${id}`);
             return data.feedback;
         },
     },

--- a/resources/js/store/adminStore.js
+++ b/resources/js/store/adminStore.js
@@ -98,6 +98,7 @@ export const useAdminStore = defineStore('admin', {
             this.villageExpGain = data.data;
         },
         /**
+         * Fetches all the feedback from back-end
          * @returns Array<import('resources/types/feedback').Feedback>
          */
         async getFeedback() {
@@ -105,6 +106,7 @@ export const useAdminStore = defineStore('admin', {
             return data.feedback;
         },
         /**
+         * Toggles the feedback's archived status
          * @param {Number} id
          * @returns Array<import('resources/types/feedback').Feedback>
          */

--- a/resources/js/store/adminStore.js
+++ b/resources/js/store/adminStore.js
@@ -97,5 +97,13 @@ export const useAdminStore = defineStore('admin', {
             const {data} = await axios.put('/admin/village_exp_gain', villageExpGain);
             this.villageExpGain = data.data;
         },
+        /**
+         * 
+         */
+        async getFeedback() {
+            //TODO
+            const {data} = await axios.get('/admin/feedback');
+            return data.feedback;
+        },
     },
 });

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -293,6 +293,9 @@
     "you": "You",
     "confirmation-delete-message": "Are you sure you want to delete this message?",
     "no-messages": "No messages found at this time. Maybe send a message to one of your friends first!",
+    
+    "archive" : "Archive",
+    "unarchive" : "Unarchive",
 
 
     "home-welcome-to": "Welcome to {0}.",

--- a/resources/types/feedback.d.ts
+++ b/resources/types/feedback.d.ts
@@ -1,0 +1,12 @@
+export type Feedback = {
+    id: Number,
+    created_at: Date,
+    type: String,
+    text: String,
+    email: String,
+    user: {
+        id: Number,
+        username: String,
+    },
+    archived: Boolean
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -119,6 +119,8 @@ Route::group(['middleware' => ['admin']], function () {
     Route::put('/admin/village_exp_gain', [AdminController::class, 'updateVillageExpGain']);
     Route::get('/admin/conversation/{id}', [AdminController::class, 'getConversationById']);
     Route::post('/admin/experience_points', [AdminController::class, 'addNewLevel']);
+    Route::get('/admin/feedback', [AdminController::class, 'getFeedback']);
+    Route::post('/admin/feedback/archive/{feedback}', [AdminController::class, 'toggleArchiveFeedback']);
 });
 
 // Route::get('/achievements', [AchievementController::class, 'showAll']);


### PR DESCRIPTION
Admins can now see the feedback and suggestions in a table.
Admins can message the user if a user is connected to it. If a user was not logged in, the send message button doesn't show up.
Admins can archive and unarchive feedback. By default archived feedback is hidden. There is a button to show/hide archived feedback.

Also worked on #371 to make life easier. Which tab you're on now shows as an anchor in the url, and when reloading, it loads whichever tab is in the url anchor.

Resolves #271 
Resolves #371 