### PR TITLE
Added max validation. Had to change migrations

### DIFF
--- a/app/Http/Requests/ConfirmRegisterRequest.php
+++ b/app/Http/Requests/ConfirmRegisterRequest.php
@@ -26,7 +26,7 @@ class ConfirmRegisterRequest extends FormRequest
     public function rules()
     {
         return [
-            'reward_object_name' => [Rule::requiredIf($this->rewardsType != 'NONE'), 'string', 'nullable'],
+            'reward_object_name' => [Rule::requiredIf($this->rewardsType != 'NONE'), 'string', 'nullable', 'max:255'],
             'rewardsType' => [new ValidRewardType()],
         ];
     }

--- a/app/Http/Requests/NewAchievementRequest.php
+++ b/app/Http/Requests/NewAchievementRequest.php
@@ -25,7 +25,7 @@ class NewAchievementRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => 'required|string',
+            'name' => 'required|string|max:255',
             'description' => 'required|string',
             'trigger_type' => 'required|exists:achievement_triggers,trigger_type',
             'trigger_amount' => 'required|integer',

--- a/app/Http/Requests/RegisterUserRequest.php
+++ b/app/Http/Requests/RegisterUserRequest.php
@@ -25,9 +25,9 @@ class RegisterUserRequest extends FormRequest
     public function rules()
     {
         return [
-            'username' => 'required|string|unique:users',
-            'email' => 'required|string|email|unique:users',
-            'password' => ['required', 'confirmed', Rules\Password::min(8)],
+            'username' => 'required|string|unique:users|max:255',
+            'email' => 'required|string|email|unique:users|max:255',
+            'password' => ['required', 'confirmed', Rules\Password::min(8), 'max:255'],
         ];
     }
 }

--- a/app/Http/Requests/SendNotificationRequest.php
+++ b/app/Http/Requests/SendNotificationRequest.php
@@ -25,8 +25,8 @@ class SendNotificationRequest extends FormRequest
     public function rules()
     {
         return [
-            'title' => 'required|string',
-            'text' => 'required|string',
+            'title' => 'required|string|max:255',
+            'text' => 'required|string|max:255',
         ];
     }
 }

--- a/app/Http/Requests/SendNotificationRequest.php
+++ b/app/Http/Requests/SendNotificationRequest.php
@@ -26,7 +26,7 @@ class SendNotificationRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'text' => 'required|string|max:255',
+            'text' => 'required|string',
         ];
     }
 }

--- a/app/Http/Requests/StoreBugReportRequest.php
+++ b/app/Http/Requests/StoreBugReportRequest.php
@@ -26,8 +26,8 @@ class StoreBugReportRequest extends FormRequest
     public function rules()
     {
         return [
-            'title' => 'required|string',
-            'page' => 'required|string',
+            'title' => 'required|string|max:255',
+            'page' => 'required|string|max:255',
             'type' => ['required','string', new ValidBugType()],
             'severity' => 'required|integer|min:1|max:5',
             'image_link' => 'nullable|string',

--- a/app/Http/Requests/StoreFeedbackRequest.php
+++ b/app/Http/Requests/StoreFeedbackRequest.php
@@ -24,7 +24,7 @@ class StoreFeedbackRequest extends FormRequest
     public function rules()
     {
         return [
-            'type' => 'required|string',
+            'type' => 'required|string|max:255',
             'text' => 'required|string',
             'email' => 'required_without:user_id|nullable|email',
             'user_id' => 'nullable|exists:users,id',

--- a/app/Http/Requests/StoreGroupRequest.php
+++ b/app/Http/Requests/StoreGroupRequest.php
@@ -25,8 +25,8 @@ class StoreGroupRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => 'required|string',
-            'description' => 'required|string',
+            'name' => 'required|string|max:255',
+            'description' => 'required|string|max:255',
             'is_public' => 'boolean|required',
         ];
     }

--- a/app/Http/Requests/StoreReportedUserRequest.php
+++ b/app/Http/Requests/StoreReportedUserRequest.php
@@ -26,7 +26,7 @@ class StoreReportedUserRequest extends FormRequest
     {
         return [
             'comment' => 'required_without:conversation_id|string|nullable',
-            'reason' => 'required|string',
+            'reason' => 'required|string|max:255',
             'conversation_id' => 'required_without:comment|string',
         ];
     }

--- a/app/Http/Requests/StoreTaskListRequest.php
+++ b/app/Http/Requests/StoreTaskListRequest.php
@@ -25,7 +25,7 @@ class StoreTaskListRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => 'required|string',
+            'name' => 'required|string|max:255',
         ];
     }
 }

--- a/app/Http/Requests/StoreTaskRequest.php
+++ b/app/Http/Requests/StoreTaskRequest.php
@@ -33,7 +33,7 @@ class StoreTaskRequest extends FormRequest
             'difficulty' => 'required|integer|max:5',
             'type' => ['required', 'string', new ValidTaskType()],
             'name' => 'required|string|max:255',
-            'description' => 'string',
+            'description' => 'string|max:255',
             'super_task_id' => ['nullable', 'integer', 'exists:tasks,id', new OwnerOfTask(Auth::user()->id)],
             'repeatable' => ['required', 'string', new ValidRepeatable()], //TODO: add to database as enum, so only takes one update? Or make new rule to limit the options
         ];

--- a/app/Http/Requests/UpdateBugReportRequest.php
+++ b/app/Http/Requests/UpdateBugReportRequest.php
@@ -28,7 +28,7 @@ class UpdateBugReportRequest extends FormRequest
         return [
             'type' => ['required','string', new ValidBugType()],
             'severity' => 'required|integer|min:1|max:5',
-            'admin_comment' => 'nullable|string',
+            'admin_comment' => 'nullable|string|max:255',
             'status' => 'required|integer|min:0|max:3',
             'title' => 'required|string',
         ];

--- a/app/Http/Requests/UpdateCharacterRequest.php
+++ b/app/Http/Requests/UpdateCharacterRequest.php
@@ -25,7 +25,7 @@ class UpdateCharacterRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => 'required|string'
+            'name' => 'required|string|max:255'
         ];
     }
 }

--- a/app/Http/Requests/UpdateGroupsRequest.php
+++ b/app/Http/Requests/UpdateGroupsRequest.php
@@ -25,8 +25,8 @@ class UpdateGroupsRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => 'sometimes|string',
-            'description' => 'sometimes|string',
+            'name' => 'sometimes|string|max:255',
+            'description' => 'sometimes|string|max:255',
             'is_public' => 'sometimes|boolean',
         ];
     }

--- a/app/Http/Requests/UpdateRewardsTypeRequest.php
+++ b/app/Http/Requests/UpdateRewardsTypeRequest.php
@@ -28,13 +28,14 @@ class UpdateRewardsTypeRequest extends FormRequest
         return [
             'rewards' => ['required', new ValidRewardType()], //TODO, exists:rewards_types,type - make rewards type migration table
             'keepOldInstance' => [Rule::requiredIf($this->rewards != 'NONE'), 'nullable'],
-            'new_object_name' => [Rule::requiredIf($this->keepOldInstance == 'NEW' && $this->rewards != 'NONE'), 'nullable', 'string'],
+            'new_object_name' => [Rule::requiredIf($this->keepOldInstance == 'NEW' && $this->rewards != 'NONE'), 'nullable', 'string', 'max:255'],
         ];
     }
 
     public function messages() {
         return [
             'keepOldInstance.required' => 'Please select whether to activate an existing instance or create a new one.',
+            'new_object_name.max' => 'The name is too long.',
             'new_object_name.*' => 'Please enter a name for this new instance.',
             'rewards.required' => 'Please pick a rewards type.',
         ];

--- a/app/Http/Requests/UpdateTaskListRequest.php
+++ b/app/Http/Requests/UpdateTaskListRequest.php
@@ -26,7 +26,7 @@ class UpdateTaskListRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => 'required|string',
+            'name' => 'required|string|max:255',
         ];
     }
 }

--- a/app/Http/Requests/UpdateTaskRequest.php
+++ b/app/Http/Requests/UpdateTaskRequest.php
@@ -34,7 +34,7 @@ class UpdateTaskRequest extends FormRequest
             'difficulty' => 'required|integer|max:5',
             'type' => ['required', 'string', new ValidTaskType()],
             'name' => 'required|string|max:255',
-            'description' => 'nullable|string',
+            'description' => 'nullable|string|max:255',
             'super_task_id' => ['nullable', 'integer', 'exists:tasks,id', new OwnerOfTask(Auth::user()->id)],
             'repeatable' => ['required', 'string', new ValidRepeatable()], //TODO: add to database as enum, so only takes one update? Or make new rule to limit the options
         

--- a/app/Http/Requests/UpdateUserEmailRequest.php
+++ b/app/Http/Requests/UpdateUserEmailRequest.php
@@ -24,7 +24,7 @@ class UpdateUserEmailRequest extends FormRequest
     public function rules()
     {
         return [
-            'email' => 'required|string|email|unique:users',
+            'email' => 'required|string|email|unique:users|max:255',
         ];
     }
 }

--- a/app/Http/Requests/UpdateUserPasswordRequest.php
+++ b/app/Http/Requests/UpdateUserPasswordRequest.php
@@ -26,8 +26,8 @@ class UpdateUserPasswordRequest extends FormRequest
     public function rules()
     {
         return [
-            'old_password' => ['required', 'string', new MatchOldPAssword()],
-            'password' => ['required', 'confirmed', Rules\Password::min(8)],
+            'old_password' => ['required', 'string', new MatchOldPAssword(), 'max:255'],
+            'password' => ['required', 'confirmed', Rules\Password::min(8), 'max:255'],
         ];
     }
 }

--- a/database/migrations/2021_06_11_132307_create_notifications_table.php
+++ b/database/migrations/2021_06_11_132307_create_notifications_table.php
@@ -17,7 +17,7 @@ class CreateNotificationsTable extends Migration
             $table->id();
             $table->timestamps();
             $table->string('title');
-            $table->string('text');
+            $table->text('text');
             $table->boolean('read')->default(false);
         });
     }

--- a/database/migrations/2021_06_11_132520_create_achievements_table.php
+++ b/database/migrations/2021_06_11_132520_create_achievements_table.php
@@ -20,8 +20,8 @@ class CreateAchievementsTable extends Migration
             $table->string('trigger_type');
             $table->integer('trigger_amount');
             $table->string('trigger_description');
-            $table->string('image')->nullable();
-            $table->string('description')->nullable();
+            $table->text('image')->nullable();
+            $table->text('description')->nullable();
         });
     }
 

--- a/database/migrations/2022_01_06_130612_create_bug_reports_table.php
+++ b/database/migrations/2022_01_06_130612_create_bug_reports_table.php
@@ -20,10 +20,10 @@ class CreateBugReportsTable extends Migration
             $table->string('page');
             $table->string('type');
             $table->integer('severity');
-            $table->string('image_link')->nullable();
+            $table->text('image_link')->nullable();
             $table->unsignedBigInteger('user_id');
-            $table->string('comment');
-            $table->string('admin_comment')->nullable();
+            $table->text('comment');
+            $table->text('admin_comment')->nullable();
             $table->integer('status')->default(0); //0 = reported, 1 = in progress, 2 = done, 3 = resolved
         });
     }


### PR DESCRIPTION
Resolves #290 
Added max validation on all strings/varchars as they are 255 characters. Had to change migrations to allow for bigger comments on bug reports and image links, as some might not work otherwise. These will only be necessary in live and can be ignored for the time being. Otherwise all strings now have extra validation to make sure they don't throw SQL errors. Anyone who goes beyond the max text on a longtext can try not to be an asshole next time, as longtext can hold like 4gb or something. For text I don't think it'll be a problem, but we'll have to see in the future.