### PR TITLE
Feature/358 admin ban suspend users

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Before launching the beta version of the site, the following things need to be f
 - [ ] Finished groups: invites to private groups, 
 # Admin and back-end
 - [ ] Admins able to view and respond to feedback
-- [ ] Admins able to view reported users and perform action: message the user, ban the user
+- [x] Admins able to view reported users and perform action: message the user, ban the user
 - [ ] Tracking of logins (attempts) for security
 - [ ] Worked out good balancing of the rewards (experience points) to start off with, and plenty of levels to gain
 

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -97,7 +97,7 @@ class AdminController extends Controller
     }
 
     /**
-     * Bans a user: Changes 'active' to current dateTime + the amount of days the user gets banned.
+     * Bans a user: Changes 'banned_until' to current dateTime + the amount of days the user gets banned.
      * Created a BannedUser to document the suspension of the account, as well as deactivates the
      * user's account.
      *
@@ -110,7 +110,7 @@ class AdminController extends Controller
         if ($validated['indefinite'] == 'true') $validated['days'] = 99999;
 
         $bannedUntilTime = Carbon::now()->addDays($validated['days']);
-        $user->active = $bannedUntilTime;
+        $user->banned_until = $bannedUntilTime;
         $user->save();
 
         BannedUser::create([

--- a/app/Http/Controllers/AuthenticationController.php
+++ b/app/Http/Controllers/AuthenticationController.php
@@ -9,6 +9,7 @@ use App\Http\Resources\UserResource;
 use App\Http\Requests\LoginRequest;
 use App\Models\User;
 use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 
@@ -24,9 +25,7 @@ class AuthenticationController extends Controller
             /** @var User */
             $user = Auth::user();
             if (!$user->isActive()){
-                $timeRemaining = Carbon::parse($user->active)->diff(Carbon::now())->format('%H:%I:%S');
-                ActionTrackingHandler::handleAction($request, 'LOGIN', 'Banned user attepted logging in '.$request['username']);
-                return new JsonResponse(['message' => ['error' => 'You are banned until ' . $user->active .'. Time remaining: ' .$timeRemaining]]);
+                return $this->handleBannedUser($user, $request);
             }
             $request->session()->regenerate();
             ActionTrackingHandler::handleAction($request, 'LOGIN', 'User logged in '.$request['username']);
@@ -36,6 +35,18 @@ class AuthenticationController extends Controller
         ActionTrackingHandler::handleAction($request, 'LOGIN', 'User failed to log in '.$request['username'], 'Invalid login');
         return new JsonResponse(['message' => $errorMessage, 'errors' => ['error' => [$errorMessage]]], Response::HTTP_UNPROCESSABLE_ENTITY);
 
+    }
+
+    private function handleBannedUser(User $user, Request $request) {
+        $timeRemaining = Carbon::parse($user->active)->diffForHumans(Carbon::now(), ['syntax' => CarbonInterface::DIFF_RELATIVE_TO_NOW]);
+        ActionTrackingHandler::handleAction($request, 'LOGIN', 'Banned user attepted logging in '.$request['username']);
+        $activeDate = $user->active;
+        $reason = $user->bannedUser->first()->reason;
+        $errorMessage = 'You are banned until %s. Reason: %s If you wish to dispute your ban, contact one of the admins on our Discord. Time remaining: %s.';
+        return new JsonResponse([
+            'message' => [
+                'error' => sprintf($errorMessage, $activeDate, $reason, $timeRemaining)], 
+            'invalid' => true]);
     }
 
     /**

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -15,6 +15,7 @@ class DashboardController extends Controller
      * Returns the task lists and character in an object
      */
     public function getDashboard(){
+        /** @var User */
         $user = Auth::user();
         $taskLists = TaskListResource::collection($user->taskLists);
         $rewardObj = RewardObjectHandler::getActiveRewardObjectResourceByUser($user->rewards, $user->id);

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -44,6 +44,10 @@ class Kernel extends HttpKernel
             'throttle:api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
+        'valid-auth' => [
+            'auth',
+            'banned',
+        ],
     ];
 
     /**
@@ -64,5 +68,6 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'admin' => \App\Http\Middleware\Admin::class,
+        'banned' => \App\Http\Middleware\UserIsNotBanned::class,
     ];
 }

--- a/app/Http/Middleware/UserIsNotBanned.php
+++ b/app/Http/Middleware/UserIsNotBanned.php
@@ -19,7 +19,7 @@ class UserIsNotBanned
     {
         /** @var User */
         $user = Auth::user();
-        if (!$user->isActive()){
+        if ($user->isBanned()){
             return response('Account suspended.', 401);
         }
         return $next($request);

--- a/app/Http/Middleware/UserIsNotBanned.php
+++ b/app/Http/Middleware/UserIsNotBanned.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class UserIsNotBanned
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        /** @var User */
+        $user = Auth::user();
+        if (!$user->isActive()){
+            return response('Account suspended.', 401);
+        }
+        return $next($request);
+    }
+}

--- a/app/Http/Requests/BanUserRequest.php
+++ b/app/Http/Requests/BanUserRequest.php
@@ -17,6 +17,13 @@ class BanUserRequest extends FormRequest
         return Auth::user()->admin;
     }
 
+    // protected function prepareForValidation()
+    // {
+    //     $this->merge([
+    //         'indefinite' => !!$this->indefinite,
+    //     ]);
+    // }
+
     /**
      * Get the validation rules that apply to the request.
      *
@@ -26,8 +33,16 @@ class BanUserRequest extends FormRequest
     {
         return [
             'reason' => 'required|string',
-            'days' => 'required_without:indefinite|integer',
-            'indefinite' => 'required_without:days|boolean',
+            'days' => 'required_if:indefinite,false|integer|min:1|nullable',
+            'indefinite' => 'required_if:days,<1|boolean',
+        ];
+    }
+
+    public function messages(){
+        return [
+            'days.required_if' => 'The amount of days is required if not indefinite.',
+            'days.min' => 'The amount of days must be more than 1 if not indefinite.',
+            'indefinite.required_if' => 'If no days are selected, please check indefinite.',
         ];
     }
 }

--- a/app/Http/Requests/BanUserRequest.php
+++ b/app/Http/Requests/BanUserRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+
+class BanUserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return Auth::user()->admin;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'reason' => 'required|string',
+            'days' => 'required_without:indefinite|integer',
+            'indefinite' => 'required_without:days|boolean',
+        ];
+    }
+}

--- a/app/Http/Resources/BannedUserResource.php
+++ b/app/Http/Resources/BannedUserResource.php
@@ -30,8 +30,5 @@ class BannedUserResource extends JsonResource
             'past' => Carbon::parse($this->banned_until)->lessThan(Carbon::now()),
             'banned_until_time' => Carbon::parse($this->banned_until)->diffForHumans(Carbon::now(), ['syntax' => CarbonInterface::DIFF_RELATIVE_TO_NOW])
         ];
-
-        // Carbon::now()->diffForHumans($this->created_at,[
-            // $this->created_at->diffForHumans(Carbon::now(),[
     }
 }

--- a/app/Http/Resources/BannedUserResource.php
+++ b/app/Http/Resources/BannedUserResource.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\StrippedUserResource;
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+
+class BannedUserResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
+     */
+    public function toArray($request)
+    {
+        return [
+            'created_at' => $this->created_at->toDateTimeString(),
+            'time_since' => $this->created_at->diffForHumans(Carbon::now(),[
+                'syntax' => CarbonInterface::DIFF_RELATIVE_TO_NOW,
+            ]),
+            'updated_at' => $this->updated_at->toDateTimeString(),
+            'reason' => $this->reason,
+            'days' => $this->days,
+            'admin' => new StrippedUserResource($this->admin),
+            'banned_until' => $this->banned_until,
+            'past' => Carbon::parse($this->banned_until)->lessThan(Carbon::now()),
+            'banned_until_time' => Carbon::parse($this->banned_until)->diffForHumans(Carbon::now(), ['syntax' => CarbonInterface::DIFF_RELATIVE_TO_NOW])
+        ];
+
+        // Carbon::now()->diffForHumans($this->created_at,[
+            // $this->created_at->diffForHumans(Carbon::now(),[
+    }
+}

--- a/app/Http/Resources/ReportedUserResource.php
+++ b/app/Http/Resources/ReportedUserResource.php
@@ -5,6 +5,7 @@ namespace App\Http\Resources;
 use Illuminate\Http\Resources\Json\JsonResource;
 use App\Models\ReportedUser;
 use App\Http\Resources\ReportedUserReportResource;
+use App\Http\Resources\BannedUserResource;
 
 class ReportedUserResource extends JsonResource
 {
@@ -22,6 +23,8 @@ class ReportedUserResource extends JsonResource
             'report_amount' => ReportedUser::where('reported_user_id', $this->id)->count(),
             'last_report_date' => $this->getLatestReport()->value('created_at')->toDateTimeString(),
             'reports' => ReportedUserReportResource::collection($this->getReports()),
+            'banned' => $this->getBannedUserResource(),
+            'active' => $this->active,
         ];
     }
 }

--- a/app/Http/Resources/ReportedUserResource.php
+++ b/app/Http/Resources/ReportedUserResource.php
@@ -24,7 +24,7 @@ class ReportedUserResource extends JsonResource
             'last_report_date' => $this->getLatestReport()->value('created_at')->toDateTimeString(),
             'reports' => ReportedUserReportResource::collection($this->getReports()),
             'banned' => $this->getBannedUserResource(),
-            'active' => $this->active,
+            'banned_until' => $this->banned_until,
         ];
     }
 }

--- a/app/Models/BannedUser.php
+++ b/app/Models/BannedUser.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class BannedUser extends Model
+{
+    protected $table = 'banned_users';
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'admin_id',
+        'reason',
+        'days',
+        'banned_until',
+    ];
+
+    public function user() {
+        return $this->belongsTo('App\Models\User');
+    }
+
+    public function admin() {
+        return $this->belongsTo('App\Models\User', 'admin_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -166,13 +166,14 @@ class User extends Authenticatable
     }
 
     /**
-     * Checks if the user is suspended by matching the 'active' date-time with the current date-time
+     * Checks if the user is suspended by matching the 'banned_until' date-time with the current date-time
      *
      * @return boolean
      */
-    public function isActive() {
+    public function isBanned() {
         $currentDate = Carbon::now();
-        if ($this->active < $currentDate) return true;
+        if (!$this->banned_until) return false;
+        if ($this->banned_until < $currentDate) return true;
         else return false;
     }
     

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 use App\Models\Task;
 use App\Helpers\RewardObjectHandler;
+use App\Http\Resources\BannedUserResource;
 use Illuminate\Support\Facades\DB;
 use App\Models\RepeatableTaskCompleted;
 use App\Models\ReportedUser;
@@ -81,6 +82,10 @@ class User extends Authenticatable
 
     public function notifications(){
         return $this->hasMany('App\Models\Notification');
+    }
+
+    public function bannedUser() {
+        return $this->hasMany('App\Models\BannedUser');
     }
 
     public function groups(){
@@ -169,5 +174,23 @@ class User extends Authenticatable
         $currentDate = Carbon::now();
         if ($this->active < $currentDate) return true;
         else return false;
+    }
+
+    /**
+     * Gets the BannedUser instance if it exists. Otherwise return null.
+     */
+    public function getBannedUser() {
+        $bannedUser = $this->bannedUser;
+        return count($bannedUser) > 0 ? $bannedUser : null;
+    }
+
+    /**
+     * Gets the BannedUser instance if it exists and wraps in a resource. Otherwise return null.
+     */
+    public function getBannedUserResource() {
+        $bannedUser = $this->bannedUser;
+        if (count($bannedUser) < 1)
+            return null;
+        return BannedUserResource::collection($bannedUser);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,6 +12,7 @@ use App\Helpers\RewardObjectHandler;
 use Illuminate\Support\Facades\DB;
 use App\Models\RepeatableTaskCompleted;
 use App\Models\ReportedUser;
+use Carbon\Carbon;
 
 class User extends Authenticatable
 {
@@ -157,5 +158,16 @@ class User extends Authenticatable
         return $allConversations->filter(function ($value, $key) {
             return $value->getLastMessage();
         });
+    }
+
+    /**
+     * Checks if the user is suspended by matching the 'active' date-time with the current date-time
+     *
+     * @return boolean
+     */
+    public function isActive() {
+        $currentDate = Carbon::now();
+        if ($this->active < $currentDate) return true;
+        else return false;
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -175,15 +175,7 @@ class User extends Authenticatable
         if ($this->active < $currentDate) return true;
         else return false;
     }
-
-    /**
-     * Gets the BannedUser instance if it exists. Otherwise return null.
-     */
-    public function getBannedUser() {
-        $bannedUser = $this->bannedUser;
-        return count($bannedUser) > 0 ? $bannedUser : null;
-    }
-
+    
     /**
      * Gets the BannedUser instance if it exists and wraps in a resource. Otherwise return null.
      */

--- a/database/migrations/2022_05_10_131431_add_active_column_to_users_table.php
+++ b/database/migrations/2022_05_10_131431_add_active_column_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddActiveColumnToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('active')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('active');
+        });
+    }
+}

--- a/database/migrations/2022_05_10_131431_add_active_column_to_users_table.php
+++ b/database/migrations/2022_05_10_131431_add_active_column_to_users_table.php
@@ -14,7 +14,7 @@ class AddActiveColumnToUsersTable extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->timestamp('active')->useCurrent();
+            $table->timestamp('banned_until')->nullable();
         });
     }
 
@@ -26,7 +26,7 @@ class AddActiveColumnToUsersTable extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('active');
+            $table->dropColumn('banned_until');
         });
     }
 }

--- a/database/migrations/2022_05_10_131452_create_banned_users_table.php
+++ b/database/migrations/2022_05_10_131452_create_banned_users_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateFeedbackTable extends Migration
+class CreateBannedUsersTable extends Migration
 {
     /**
      * Run the migrations.
@@ -13,17 +13,20 @@ class CreateFeedbackTable extends Migration
      */
     public function up()
     {
-        Schema::create('feedback', function (Blueprint $table) {
+        Schema::create('banned_users', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
-            $table->string('type');
-            $table->longText('text');
-            $table->string('email')->nullable();
             $table->unsignedBigInteger('user_id')->nullable();
-            $table->boolean('archived')->default(false);
+            $table->text('reason');
+            $table->unsignedBigInteger('admin_id')->nullable();
+            $table->integer('days');
+            $table->timestamp('banned_until')->useCurrent();
         });
-        Schema::table('feedback', function (Blueprint $table){
+        Schema::table('banned_users', function (Blueprint $table){
             $table->foreign('user_id')
+                ->references('id')->on('users')
+                ->onDelete('set null');
+            $table->foreign('admin_id')
                 ->references('id')->on('users')
                 ->onDelete('set null');
         });
@@ -36,6 +39,6 @@ class CreateFeedbackTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('feedback');
+        Schema::dropIfExists('banned_users');
     }
 }

--- a/resources/assets/scss/app.scss
+++ b/resources/assets/scss/app.scss
@@ -7,6 +7,7 @@
 /*
 Cheat sheet
 border-radius: top-left top-right bottom-right bottom-left;
+margin: top right bottom left;
 */
 
 * {
@@ -34,23 +35,6 @@ p {
 }
 label, b {
     font-weight: 500;
-}
-
-#footer {
-    background-color: $background-darker;
-    margin-top: auto;
-    width: 100%;
-    height: 9rem;
-    a{
-        width: fit-content;
-    }
-    .footer-text{
-        margin-top: -20px;
-        position: absolute;
-        right: 10%;
-        display: flex;
-        flex-direction: column;
-    }
 }
 
 //New and copied, can be toned down

--- a/resources/assets/scss/app.scss
+++ b/resources/assets/scss/app.scss
@@ -438,6 +438,11 @@ input:focus {
     border: 1px solid #495057;
     box-shadow: 0 0.15rem 0.15rem rgb(0 0 0 / 15%);
 }
+.invalid-feedback {
+    color: $red;
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+}
 
 select {
     display: inline-block;

--- a/resources/js/components/FooterComp.vue
+++ b/resources/js/components/FooterComp.vue
@@ -1,6 +1,12 @@
 <template>
     <div id="footer">
-        <p class="silent">{{ $t('footer-text') }}</p>
+        <div class="footer-text-left">
+            <p class="silent">{{ $t('footer-text') }}</p>
+            <p class="silent">{{ $t('footer-disclaimer') }}</p>
+            <a class="silent mb-1" :href="$t('discord-link')" target="_blank">
+                {{ $t('discord-link') }}
+            </a>
+        </div>
         <div class="footer-text">
             <router-link class="silent mb-1" to="/faq">{{ $t('faq') }}</router-link>
             <a class="silent mb-1" href="https://github.com/MJZwart/motivation-app#roadmap" target="_blank">
@@ -11,3 +17,33 @@
         </div>
     </div>
 </template>
+
+<style lang="scss" scoped>
+@import '../../assets/scss/variables.scss';
+#footer {
+    background-color: $background-darker;
+    margin-top: auto;
+    width: 100%;
+    height: fit-content;
+    display: flex;
+    a{
+        width: fit-content;
+    }
+    .footer-text{
+        margin-top: auto;
+        margin-bottom: auto;
+        margin-right: 2rem;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+    }
+    .footer-text-left {
+        position: relative;
+        margin: auto 1rem auto 1rem;
+        min-width: 6rem;
+        p{
+            margin: 0.5rem auto;
+        }
+    }
+}
+</style>

--- a/resources/js/components/global/BaseFormError.vue
+++ b/resources/js/components/global/BaseFormError.vue
@@ -21,12 +21,3 @@ const errorMsg = computed(() => {
     return (errors[props.name] || [])[0] || '';
 });
 </script>
-
-<style lang="scss" scoped>
-@import '../../../assets/scss/variables';
-.invalid-feedback {
-    color: $red;
-    font-size: 0.875rem;
-    margin-top: 0.25rem;
-}
-</style>

--- a/resources/js/components/global/Input.vue
+++ b/resources/js/components/global/Input.vue
@@ -69,12 +69,3 @@ const errorMsg = computed(() => {
     return (errors.value[props.name] || [])[0] || '';
 });
 </script>
-
-<style lang="scss" scoped>
-@import '../../../assets/scss/variables';
-.invalid-feedback {
-    color: $red;
-    font-size: 0.875rem;
-    margin-top: 0.25rem;
-}
-</style>

--- a/resources/js/components/global/Textarea.vue
+++ b/resources/js/components/global/Textarea.vue
@@ -65,12 +65,3 @@ const errorMsg = computed(() => {
     return (errors.value[props.name] || [])[0] || '';
 });
 </script>
-
-<style lang="scss" scoped>
-@import '../../../assets/scss/variables';
-.invalid-feedback {
-    color: $red;
-    font-size: 0.875rem;
-    margin-top: 0.25rem;
-}
-</style>

--- a/resources/js/constants/reportUserConstants.js
+++ b/resources/js/constants/reportUserConstants.js
@@ -22,8 +22,12 @@ export const REPORTED_USER_FIELDS = [
         sortable: true,
     },
     {
-        label: 'Details',
-        key: 'details',
+        label: 'Actions',
+        key: 'actions',
+    },
+    {
+        label: 'Banned',
+        key: 'banned',
     },
 ];
 

--- a/resources/js/pages/Login.vue
+++ b/resources/js/pages/Login.vue
@@ -1,6 +1,7 @@
 <template>
     <div class="w-40-flex center">
         <h2>{{ $t('login') }}</h2>
+        <p v-if="info" class="invalid-feedback">{{info.error}}</p>
         <form @submit.prevent="submitLogin">
             <Input 
                 id="username" 
@@ -25,7 +26,7 @@
 
 <script setup>
 import {useUserStore} from '/js/store/userStore';
-import {reactive} from 'vue';
+import {reactive, ref} from 'vue';
 
 const login = reactive({
     username: '',
@@ -33,8 +34,9 @@ const login = reactive({
 });
 
 const userStore = useUserStore();
+const info = ref(null);
 
-function submitLogin() {
-    userStore.login(login);
+async function submitLogin() {
+    info.value = await userStore.login(login);
 }
 </script>

--- a/resources/js/pages/Login.vue
+++ b/resources/js/pages/Login.vue
@@ -7,7 +7,7 @@
                 v-model="login.username" 
                 name="username"
                 type="text" 
-                :label="$t('password')"
+                :label="$t('username')"
                 :placeholder="$t('username')" />
             <Input  
                 id="password" 

--- a/resources/js/pages/admin/components/ReportedUserDetails.vue
+++ b/resources/js/pages/admin/components/ReportedUserDetails.vue
@@ -57,10 +57,6 @@ defineProps({
         type: Object,
         required: true,
     },
-    index: {
-        type: Number,
-        reqired: true,
-    },
 });
 
 const reportedUserDetailsFields = REPORTED_USER_DETAILS_FIELDS;

--- a/resources/js/pages/admin/components/SuspendUserModal.vue
+++ b/resources/js/pages/admin/components/SuspendUserModal.vue
@@ -1,0 +1,60 @@
+<template>
+    <div>
+        <form @submit.prevent="suspendUser">
+            <Textarea 
+                id="reason" 
+                v-model="suspension.reason"
+                :rows="2"
+                name="reason" 
+                :label="$t('reason')"
+                :placeholder="$t('reason')"  />
+            <Input 
+                id="days" 
+                v-model="suspension.days"
+                type="number" 
+                name="days" 
+                :label="$t('days')"
+                :placeholder="$t('days')"  />
+            <div class="form-group">
+                <input 
+                    id="indefinite" 
+                    v-model="suspension.indefinite"
+                    type="checkbox" 
+                    name="indefinite" 
+                    :label="$t('indefinite')"
+                    :placeholder="$t('indefinite')" />
+                <label for="indefinite">{{ $t('indefinite') }}</label>
+                <BaseFormError name="indefinite" />
+            </div>
+            <button type="submit" class="block">{{ $t('suspend-user') }}</button>
+            <button type="button" class="block" @click="emit('close')">{{ $t('cancel') }}</button>
+        </form>
+    </div>
+</template>
+
+<script setup>
+import {ref} from 'vue';
+import {useAdminStore} from '/js/store/adminStore';
+const adminStore = useAdminStore();
+
+const props = defineProps({
+    userId: {
+        type: Number,
+        required: true,
+    },
+});
+const emit = defineEmits(['close']);
+
+const suspension = ref({
+    reason: '',
+    days: 0,
+    indefinite: false,
+});
+
+async function suspendUser() {
+    if (suspension.value.indefinite) suspension.value.days = null;
+    await adminStore.suspendUser(props.userId, suspension.value);
+    emit('close');
+}
+
+</script>

--- a/resources/js/pages/admin/tabs/ReportedUsers.vue
+++ b/resources/js/pages/admin/tabs/ReportedUsers.vue
@@ -7,15 +7,33 @@
             :fields="reportedUserFields"
             :options="['table-striped', 'page-wide']"
         >
-            <template #details="row">
+            <template #actions="row">
                 <Tooltip :text="$t('show-details')">
                     <FaIcon 
                         icon="magnifying-glass" 
                         class="icon"
-                        @click="showReportedUserDetails(row)">
+                        @click="showReportedUserDetails(row.item)">
                         {{ $t('show-details') }}
                     </FaIcon>                        
                 </Tooltip>
+                <Tooltip :text="$t('suspend-user')">
+                    <FaIcon 
+                        icon="ban" 
+                        class="icon red"
+                        @click="suspendUser(row.item)" />                        
+                </Tooltip>
+            </template>
+            <template #banned="row">
+                <div v-if="row.item.banned">
+                    <div v-for="(banned, index) in row.item.banned" :key="index" class="banned-details">
+                        <hr v-if="index > 0" />
+                        <p>{{banned.created_at}} ({{banned.time_since}})</p>
+                        <p>{{$t('banned-by')}}: {{banned.admin.username}}</p>
+                        <p>{{$t('reason')}}: {{banned.reason}}</p>
+                        <p>{{banned.days}} {{$t('days')}}</p>
+                        <p>{{$t('banned-until')}}: {{banned.banned_until}} ({{banned.banned_until_time}})</p>
+                    </div>
+                </div>
             </template>
         </Table>
         <Modal 
@@ -24,7 +42,16 @@
             :title="reportedUserDetailsTitle" 
             class="l"
             @close="closeReportedUserDetails">
-            <ReportedUserDetails :user="reportedUserDetails" :index="reportedUserIndex" />
+            <ReportedUserDetails :user="reportedUserDetails" />
+        </Modal>
+        <Modal
+            :show="showSuspendUserModal"
+            :footer="false"
+            :title="suspendUserTitle"
+            @close="closeSuspendUserModal">
+            <SuspendUserModal 
+                :userId="suspendedUser.id" 
+                @close="closeSuspendUserModal" />
         </Modal>
     </div>
 </template>
@@ -33,25 +60,55 @@
 import Table from '/js/components/global/Table.vue';
 import {ref, computed} from 'vue';
 import ReportedUserDetails from './../components/ReportedUserDetails.vue';
+import SuspendUserModal from './../components/SuspendUserModal.vue';
 import {REPORTED_USER_FIELDS} from '/js/constants/reportUserConstants.js';
 import {useAdminStore} from '/js/store/adminStore';
 const adminStore = useAdminStore();
+import {useMainStore} from '/js/store/store';
+const mainStore = useMainStore();
 
 const reportedUserDetails = ref(null);
-const reportedUserIndex = ref(null);
 const reportedUserFields = ref(REPORTED_USER_FIELDS);
-const reportedUserDetailsTitle = ref(null);
+const reportedUserDetailsTitle = computed(() => {
+    const username = reportedUserDetails.value ? reportedUserDetails.value.username : '';
+    return `Reported user ${username}`;
+});
+
+const suspendedUser = ref(null);
+const suspendUserTitle = computed(() => {
+    const username = suspendedUser.value ? suspendedUser.value.username: '';
+    return `Suspend user ${username}`;
+});
+
 const showReportedUserDetailsModal = ref(false);
+const showSuspendUserModal = ref(false);
 
 const reportedUsers = computed(() => adminStore.reportedUsers);
 
-function showReportedUserDetails({item, index}) {
+/** Opens the modal to show details on the user report */
+function showReportedUserDetails(item) {
     reportedUserDetails.value = item;
-    reportedUserIndex.value = index;
-    reportedUserDetailsTitle.value = item.username;
     showReportedUserDetailsModal.value = true;
 }
 function closeReportedUserDetails() {
     showReportedUserDetailsModal.value = false;
 }
+
+/** Opens the modal to suspend a user account */
+function suspendUser(item) {
+    mainStore.clearErrors();
+    suspendedUser.value = item;
+    showSuspendUserModal.value = true;
+}
+function closeSuspendUserModal() {
+    showSuspendUserModal.value = false;
+}
 </script>
+
+<style lang="scss" scoped>
+.banned-details {
+    p{
+        margin: 0.1rem;
+    }
+}
+</style>

--- a/resources/js/store/adminStore.js
+++ b/resources/js/store/adminStore.js
@@ -97,5 +97,15 @@ export const useAdminStore = defineStore('admin', {
             const {data} = await axios.put('/admin/village_exp_gain', villageExpGain);
             this.villageExpGain = data.data;
         },
+
+        /**
+         * Suspends a user account for x amount of days, or indefinite
+         * @param {Number} userId 
+         * @param {Object} suspension 
+         */
+        async suspendUser(userId, suspension) {
+            const {data} = await axios.post(`/admin/suspend/${userId}`, suspension);
+            this.reportedUsers = data.data;
+        },
     },
 });

--- a/resources/js/store/userStore.js
+++ b/resources/js/store/userStore.js
@@ -23,12 +23,14 @@ export const useUserStore = defineStore('user', {
     },
     actions: {
         /**
-         * User authentication
+         * User authentication. If user login is valid but the account is otherwise invalidated, 
+         * instead return info the Login screen.
          * @param {import('resources/types/user').User} user
          */
         async login(user) {
             await axios.get('/sanctum/csrf-cookie');
             const {data} = await axios.post('/login', user);
+            if (data.invalid) return data.message;
             this.setUser(data.user);
             router.push('/dashboard').catch(() => {});
         },

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1,6 +1,10 @@
 {
     "app-name": "Dumb Bitch Simulator",
-    "faq": "Frequently Asked Questions",
+    "faq": "F.A.Q.",
+    "footer-text": "Version 0.1.2 ALPHA - MJ Black © 2022.",
+    "footer-disclaimer": "This is an alpha version. This website is unfinished and subject to major changes. Join our discord for updates and discuss your ideas for the site.",
+    "discord-link": "https://discord.gg/r3sjMDgyA2",
+
 
     "create-new-task-list": "Create new task list",
     "create-new-task": "Create new task",
@@ -272,8 +276,7 @@
     "yes": "Yes",
     "no": "No",
 
-    "footer-text": "Version 1.0 - MJ Black © 2021.",
-    "feedback": "Feedback",
+        "feedback": "Feedback",
     "feedback-explanation": "Do you have any feedback for us? Features you'd like to suggest, new ideas for content, opinions on the site overall? Please fill in this form and we'll contact you if we have any questions or remarks.",
     "feedback-features-header": "Requesting features",
     "feedback-features": "Do you have ideas for a new feature? Try to describe your idea as detailed as possible. What do you want it to do? Where would you like to see it? We can further discuss these ideas on our Discord.",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -181,6 +181,12 @@
     "message-reported-user": "Message reported user",
     "see-conversation": "See conversation",
     "see-conversation-reporter": "Showing conversation between reported user {reportedUser} and reporter.",
+    "suspend-user": "Suspend user",
+    "days" : "Days",
+    "reason": "Reason",
+    "indefinite" : "Indefinite",
+    "banned-by": "Banned by",
+    "banned-until": "Banned until",
     
 
     "manage-achievements": "Manage achievements",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -282,7 +282,7 @@
     "yes": "Yes",
     "no": "No",
 
-        "feedback": "Feedback",
+    "feedback": "Feedback",
     "feedback-explanation": "Do you have any feedback for us? Features you'd like to suggest, new ideas for content, opinions on the site overall? Please fill in this form and we'll contact you if we have any questions or remarks.",
     "feedback-features-header": "Requesting features",
     "feedback-features": "Do you have ideas for a new feature? Try to describe your idea as detailed as possible. What do you want it to do? Where would you like to see it? We can further discuss these ideas on our Discord.",

--- a/routes/api.php
+++ b/routes/api.php
@@ -42,7 +42,7 @@ Route::post('/login', [AuthenticationController::class, 'authenticate']);
 Route::post('/logout', [AuthenticationController::class, 'logout']);
 Route::post('/register', [RegisteredUserController::class, 'store']);
 
-Route::group(['middleware' => ['auth']], function () {
+Route::group(['middleware' => ['valid-auth']], function () {
     Route::resource('/tasks', TaskController::class)->only([
         'store', 'show', 'update', 'destroy'
     ]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\AuthenticationController;
 use App\Http\Controllers\RegisteredUserController;
 use App\Http\Controllers\TaskListController;
 use App\Http\Controllers\TaskController;
-use App\Http\Controllers\AchievementController;
 use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\FriendController;
@@ -17,7 +16,6 @@ use App\Http\Controllers\OverviewController;
 use App\Http\Controllers\RewardController;
 use App\Http\Controllers\MessageController;
 use App\Http\Controllers\GroupsController;
-use App\Http\Controllers\AdminController;
 use App\Http\Controllers\FeedbackController;
 
 /*
@@ -35,7 +33,10 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-//Middleware for admin
+$routes = str_replace(".php", "", array_diff(scandir(base_path() . '/routes/api'), array('.', '..')));
+foreach ($routes as $route) {
+    Route::prefix($route)->group(base_path('routes/api/' . $route . '.php'));
+}
 
 Route::post('/login', [AuthenticationController::class, 'authenticate']);
 Route::post('/logout', [AuthenticationController::class, 'logout']);
@@ -106,19 +107,6 @@ Route::group(['middleware' => ['auth']], function () {
     Route::get('/unread', [UserController::class, 'hasUnread']);
 
     Route::post('/user/{user}/report', [UserController::class, 'reportUser']);
-});
-
-Route::group(['middleware' => ['admin']], function () {
-
-    Route::resource('/achievements', AchievementController::class)->only([
-        'store', 'update',
-    ]);
-    Route::get('/admin/dashboard', [AdminController::class, 'getAdminDashboard']);
-    Route::put('/admin/experience_points', [AdminController::class, 'updateExeriencePoints']);
-    Route::put('/admin/character_exp_gain', [AdminController::class, 'updateCharacterExpGain']);
-    Route::put('/admin/village_exp_gain', [AdminController::class, 'updateVillageExpGain']);
-    Route::get('/admin/conversation/{id}', [AdminController::class, 'getConversationById']);
-    Route::post('/admin/experience_points', [AdminController::class, 'addNewLevel']);
 });
 
 // Route::get('/achievements', [AchievementController::class, 'showAll']);

--- a/routes/api/admin.php
+++ b/routes/api/admin.php
@@ -28,4 +28,6 @@ Route::group(['middleware' => ['admin']], function () {
     Route::get('/conversation/{id}', [AdminController::class, 'getConversationById']);
     Route::post('/experience_points', [AdminController::class, 'addNewLevel']);
     Route::post('/suspend/{user}', [AdminController::class, 'banUser']);
+    Route::get('/feedback', [AdminController::class, 'getFeedback']);
+    Route::post('/feedback/archive/{feedback}', [AdminController::class, 'toggleArchiveFeedback']);
 });

--- a/routes/api/admin.php
+++ b/routes/api/admin.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AchievementController;
+use App\Http\Controllers\AdminController;
+
+/*
+|--------------------------------------------------------------------------
+| Admin API Routes
+|--------------------------------------------------------------------------
+|
+| All API calls that have the admin middleware. Users should not be able 
+| to reach any of these, as protected by both the router and the Requests
+| validation.
+|
+*/
+
+//Middleware for admin
+Route::group(['middleware' => ['admin']], function () {
+
+    Route::resource('/achievements', AchievementController::class)->only([
+        'store', 'update',
+    ]);
+    Route::get('/dashboard', [AdminController::class, 'getAdminDashboard']);
+    Route::put('/experience_points', [AdminController::class, 'updateExeriencePoints']);
+    Route::put('/character_exp_gain', [AdminController::class, 'updateCharacterExpGain']);
+    Route::put('/village_exp_gain', [AdminController::class, 'updateVillageExpGain']);
+    Route::get('/conversation/{id}', [AdminController::class, 'getConversationById']);
+    Route::post('/experience_points', [AdminController::class, 'addNewLevel']);
+    Route::post('/suspend/{user}', [AdminController::class, 'banUser']);
+});

--- a/todo.md
+++ b/todo.md
@@ -11,7 +11,7 @@ Before launching the beta version of the site, the following things need to be f
 - [x] Tooltips on all buttons and otherwise unclear data
 - [ ] A tutorial or 'help what do I do here' button on every page https://github.com/MJZwart/motivation-app/issues/273
 # Users and interaction
-- [ ] Allowing users to manage their blocklist and search for friends to add https://github.com/MJZwart/motivation-app/issues/250
+- [x] Allowing users to manage their blocklist and search for friends to add https://github.com/MJZwart/motivation-app/issues/250
 - [ ] Allow a user to manage the group they are an admin of https://github.com/MJZwart/motivation-app/issues/302
 - [x] Fully allowing a user to manage their characters or villages (rename them, see their level)
 - [ ] Finished groups: invites to private groups
@@ -19,8 +19,8 @@ Before launching the beta version of the site, the following things need to be f
 - https://github.com/MJZwart/motivation-app/issues/263
 - https://github.com/MJZwart/motivation-app/issues/193
 # Admin and back-end
-- [ ] Admins able to view and respond to feedback https://github.com/MJZwart/motivation-app/issues/271
-- [ ] Admins able to view reported users and perform action: message the user, ban the user https://github.com/MJZwart/motivation-app/issues/358
+- [x] Admins able to view and respond to feedback https://github.com/MJZwart/motivation-app/issues/271
+- [x] Admins able to view reported users and perform action: message the user, ban the user https://github.com/MJZwart/motivation-app/issues/358
 - [ ] Tracking of logins (attempts) for security
 - [ ] Worked out good balancing of the rewards (experience points) to start off with, and plenty of levels to gain https://github.com/MJZwart/motivation-app/issues/276
 


### PR DESCRIPTION
- Added a button to ban a user. This opens a modal with place for a reason, amount of days, or indefinite.
- When sent, this changes the 'active' date to current timestamp + amount of days banned
- When used next logins or performs any back-end action, they get logged out and invalidated. This checks if `active` date is lower than current date.
- When a user tries to log in, it shows the user that they are banned, for how long, the reason, and that they can dispute it on Discord. 
- Created middleware that checks if a user is set to active. This middleware is set on all `auth` middleware, renamed that to `valid-auth` to use both the new and the existing `auth` middleware.
- Made some changes to the footer in terms of text and placement