### PR TITLE
Bug/381 tooltip css

### DIFF
--- a/resources/js/components/global/Tooltip.vue
+++ b/resources/js/components/global/Tooltip.vue
@@ -3,7 +3,7 @@
         <div @mouseover="showTooltip = true" @mouseleave="showTooltip = false">
             <slot />
         </div>
-        <div v-show="showTooltip" ref="tooltip" class="tooltip" :class="tooltipPosition">
+        <div v-show="showTooltip" class="tooltip" :class="tooltipPosition">
             <span class="text">
                 {{text}}
             </span>

--- a/resources/js/components/global/Tooltip.vue
+++ b/resources/js/components/global/Tooltip.vue
@@ -3,7 +3,7 @@
         <div @mouseover="showTooltip = true" @mouseleave="showTooltip = false">
             <slot />
         </div>
-        <div v-show="showTooltip" class="tooltip">
+        <div v-show="showTooltip" ref="tooltip" class="tooltip" :class="tooltipPosition">
             <span class="text">
                 {{text}}
             </span>
@@ -12,13 +12,21 @@
 </template>
 
 <script setup>
-import {ref} from 'vue';
-defineProps({
+import {ref, computed} from 'vue';
+const props = defineProps({
     text: {
         type: String,
         required: true,
     },
+    placement: {
+        type: String,
+        required: false,
+        default: 'top',
+    },
 });
+
+const tooltipPosition = computed(() => props.placement);
+
 const showTooltip = ref(false);
 </script>
 
@@ -42,7 +50,7 @@ const showTooltip = ref(false);
     transition: opacity 0.5s;
 
     position: absolute;
-    z-index: 1;
+    z-index: 99999;
 
     background: #000000;
 }
@@ -57,5 +65,39 @@ const showTooltip = ref(false);
     border-style: solid;
     border-color: #000000 transparent transparent transparent;
 
+}
+
+.tooltip.right {
+    left: 0;
+    bottom: 0;
+    transform: translateX(20%) translateY(10%);
+    .text::after {
+        top: 37%;
+        left: -4%;
+        margin-top: 0px;
+        border-color: transparent #000000 transparent transparent;
+    }
+}
+.tooltip.left {
+    left: 0;
+    bottom: 0;
+    transform: translateX(-103%);
+    .text::after {
+        top: 37%;
+        left: 100%;
+        margin-left: 0px;
+        border-color: transparent transparent transparent #000000;
+    }
+}
+.tooltip.bottom {
+    left: 50%;
+    bottom: -35px;
+    transform: translateX(-50%);
+    .text::after {
+        top: -30%;
+        left: 50%;
+        margin-left: -5px;
+        border-color: transparent transparent #000000 transparent;
+    }
 }
 </style>

--- a/resources/js/pages/admin/components/EditBan.vue
+++ b/resources/js/pages/admin/components/EditBan.vue
@@ -10,7 +10,7 @@
             :disabled="userBanToEdit.end_ban == true"
             min="1" />
         <p>
-            <Tooltip :text="$t('reset-days')">
+            <Tooltip :text="$t('reset-days')" placement="right">
                 <FaIcon 
                     icon="repeat"
                     class="icon small"

--- a/resources/js/pages/dashboard/components/Task.vue
+++ b/resources/js/pages/dashboard/components/Task.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <p class="task-title d-flex">
-            <Tooltip :text="$t('complete-task')">
+            <Tooltip :text="$t('complete-task')" placement="right">
                 <FaIcon 
                     :icon="['far', 'square-check']"
                     class="icon small green"

--- a/resources/js/pages/dashboard/components/TaskList.vue
+++ b/resources/js/pages/dashboard/components/TaskList.vue
@@ -5,13 +5,13 @@
                 <span class="d-flex">
                     {{taskList.name}}
                     <span class="ml-auto">
-                        <Tooltip :text="$t('edit-task-list')">
+                        <Tooltip :text="$t('edit-task-list')" placement="bottom">
                             <FaIcon 
                                 :icon="['far', 'pen-to-square']"
                                 class="icon white small"
                                 @click="showEditTaskList()" />
                         </Tooltip>
-                        <Tooltip :text="$t('delete-task-list')">
+                        <Tooltip :text="$t('delete-task-list')" placement="bottom">
                             <FaIcon 
                                 icon="trash"
                                 class="icon small white"


### PR DESCRIPTION
Tooltips now have a prop for placement. Couldn't find a way to have it dynamically work, so right now it's hard coded. When you notice it falls off, add a prop with placement. Default is always top. There is 'right', 'bottom' and 'left'.