### PR TITLE
Switched to ISO timestrongs and parses locally

### DIFF
--- a/app/Http/Resources/AdminMessageResource.php
+++ b/app/Http/Resources/AdminMessageResource.php
@@ -17,7 +17,7 @@ class AdminMessageResource extends JsonResource
     {
         return [
             'id' => $this->id,
-            'created_at' => $this->created_at->toDateTimeString(),
+            'created_at' => $this->created_at,
             'sender_id' => $this->sender_id,
             'sender_username' => $this->sender->username,
             'message' => $this->message,

--- a/app/Http/Resources/BannedUserResource.php
+++ b/app/Http/Resources/BannedUserResource.php
@@ -19,11 +19,11 @@ class BannedUserResource extends JsonResource
     {
         return [
             'id' => $this->id,
-            'created_at' => $this->created_at->toDateTimeString(),
+            'created_at' => $this->created_at,
             'time_since' => $this->created_at->diffForHumans(Carbon::now(),[
                 'syntax' => CarbonInterface::DIFF_RELATIVE_TO_NOW,
             ]),
-            'updated_at' => $this->updated_at->toDateTimeString(),
+            'updated_at' => $this->updated_at,
             'user' => new StrippedUserResource($this->user),
             'reason' => $this->reason,
             'days' => $this->days,

--- a/app/Http/Resources/BlockedUserResource.php
+++ b/app/Http/Resources/BlockedUserResource.php
@@ -18,7 +18,7 @@ class BlockedUserResource extends JsonResource
             'id' => $this->id,
             'blocked_user_id' => $this->blocked_user_id,
             'blocked_user' => $this->blockedUser()->pluck('username')->first(),
-            'created_at' => $this->created_at->toDateTimeString(),
+            'created_at' => $this->created_at,
         ];
     }
 }

--- a/app/Http/Resources/BugReportResource.php
+++ b/app/Http/Resources/BugReportResource.php
@@ -16,8 +16,8 @@ class BugReportResource extends JsonResource
     {
         return [
             'id' => $this->id,
-            'time_created' => $this->created_at->toDateTimeString(),
-            'time_updated' => $this->updated_at->toDateTimeString(),
+            'time_created' => $this->created_at,
+            'time_updated' => $this->updated_at,
             'title' => $this->title,
             'page' => $this->page,
             'type' => $this->type,

--- a/app/Http/Resources/ConversationOverviewResource.php
+++ b/app/Http/Resources/ConversationOverviewResource.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Resources;
 
+use Carbon\Carbon;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Auth;
 
 class ConversationOverviewResource extends JsonResource
 {
@@ -20,7 +22,7 @@ class ConversationOverviewResource extends JsonResource
             'conversation_id' => $this->conversation_id,
             'last_message' => MessageResource::make($this->getLastMessage())->setUserId($this->user_id),
             'messages' => MessageResource::collection($this->visibleMessages()->sortByDesc('created_at'))->setUserId($this->user_id),
-            'updated_at' => $this->updated_at->toDateTimeString(),
+            'updated_at' => $this->updated_at,
         ];
     }
 }

--- a/app/Http/Resources/FeedbackResource.php
+++ b/app/Http/Resources/FeedbackResource.php
@@ -17,8 +17,8 @@ class FeedbackResource extends JsonResource
     {
         return [
             'id' => $this->id,
-            'created_at' => $this->created_at->toDateTimeString(),
-            'updated_at' => $this->updated_at->toDateTimeString(),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
             'type' => $this->type,
             'text' => $this->text,
             'email' => $this->email,

--- a/app/Http/Resources/GroupResource.php
+++ b/app/Http/Resources/GroupResource.php
@@ -18,8 +18,8 @@ class GroupResource extends JsonResource
     {
         return [
             'id' => $this->id,
-            'time_created' => $this->created_at->toDateTimeString(),
-            'time_updated' => $this->updated_at->toDateTimeString(),
+            'time_created' => $this->created_at,
+            'time_updated' => $this->updated_at,
             'name' => $this->name,
             'description' => $this->description,
             'is_public' => (boolean) $this->is_public,

--- a/app/Http/Resources/IncomingFriendRequestResource.php
+++ b/app/Http/Resources/IncomingFriendRequestResource.php
@@ -19,7 +19,7 @@ class IncomingFriendRequestResource extends JsonResource
             'id' => $this->friend->id,
             'friendship_id' => $this->id,
             'friend' => $this->user->username,
-            'sent' => $this->created_at->toDateTimeString(),
+            'sent' => $this->created_at,
         ];
     }
 }

--- a/app/Http/Resources/MessageResource.php
+++ b/app/Http/Resources/MessageResource.php
@@ -23,7 +23,7 @@ class MessageResource extends JsonResource
         $resourceData = [
             'id' => $this->id,
             'message' => $this->message,
-            'created_at' => $this->created_at->toDateTimeString(),
+            'created_at' => $this->created_at,
         ];
         if($this->user_id == $this->sender->id && $this->visible_to_sender) {
             $resourceData['sent_by_user'] = true;

--- a/app/Http/Resources/MyGroupResource.php
+++ b/app/Http/Resources/MyGroupResource.php
@@ -16,8 +16,8 @@ class MyGroupResource extends JsonResource
     {
         return [
             'id' => $this->id,
-            'time_created' => $this->created_at->toDateTimeString(),
-            'time_updated' => $this->updated_at->toDateTimeString(),
+            'time_created' => $this->created_at,
+            'time_updated' => $this->updated_at,
             'name' => $this->name,
             'description' => $this->description,
             'is_public' => (boolean) $this->is_public,

--- a/app/Http/Resources/NotificationResource.php
+++ b/app/Http/Resources/NotificationResource.php
@@ -17,7 +17,7 @@ class NotificationResource extends JsonResource
         return [
             'id' => $this->id,
             'read' => !!$this->read,
-            'created_at' => $this->created_at->toDateTimeString(),
+            'created_at' => $this->created_at,
             'title' => $this->title,
             'text' => $this->text,
         ];

--- a/app/Http/Resources/OutgoingFriendRequestResource.php
+++ b/app/Http/Resources/OutgoingFriendRequestResource.php
@@ -19,7 +19,7 @@ class OutgoingFriendRequestResource extends JsonResource
             'id' => $this->friend->id,
             'friendship_id' => $this->id,
             'friend' => $this->friend->username,
-            'sent' => $this->created_at->toDateTimeString(),
+            'sent' => $this->created_at,
         ];
     }
 }

--- a/app/Http/Resources/UserReportResource.php
+++ b/app/Http/Resources/UserReportResource.php
@@ -17,7 +17,7 @@ class UserReportResource extends JsonResource
     {
         return [
             'comment' => $this->comment,
-            'reported_date' => $this->created_at->toDateTimeString(),
+            'reported_date' => $this->created_at,
             'reported_by_id' => $this->reported_by_user_id,
             'reported_by_name' => $this->reporter->username,
             'conversation' => (int) $this->conversation_id,

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -41,7 +41,7 @@ class Task extends Model
     public function activeSubTasks(){
         return $this->subTasks->filter(function ($value, $key) {
             return $value->completed == null
-                && $value->repeatable_active <= Carbon::now()->toDateTimeString()
+                && $value->repeatable_active <= Carbon::now()
                 ;});
     }
 }

--- a/app/Models/TaskList.php
+++ b/app/Models/TaskList.php
@@ -25,7 +25,7 @@ class TaskList extends Model
         return $this->tasks->filter(function ($value, $key) {
                 return $value->super_task_id == null 
                     && $value->completed == null
-                    && $value->repeatable_active <= Carbon::now()->toDateTimeString()
+                    && $value->repeatable_active <= Carbon::now()
                     ;});
     }
 

--- a/database/migrations/2022_06_15_080624_add_timezone_to_users_table.php
+++ b/database/migrations/2022_06_15_080624_add_timezone_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddTimezoneToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('timezone')->default('UTC');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/resources/js/pages/admin/tabs/BannedUsers.vue
+++ b/resources/js/pages/admin/tabs/BannedUsers.vue
@@ -9,6 +9,9 @@
                 :fields="bannedUsersFields"
                 :options="['table-striped', 'page-wide', 'body-borders']"
             >
+                <template #created_at="row">
+                    {{parseDateTime(row.item.created_at)}}
+                </template>
                 <template #user="row">
                     <router-link :to="{ name: 'profile', params: { id: row.item.user.id}}">
                         {{row.item.user.username}}
@@ -21,10 +24,10 @@
                 </template>
                 <template #banned_until="row">
                     <span v-if="row.item.early_release">
-                        {{row.item.early_release}}
+                        {{parseDateTime(row.item.early_release, true)}}
                     </span>
                     <span v-else>
-                        {{row.item.banned_until}}
+                        {{parseDateTime(row.item.banned_until, true)}}
                     </span>
                     <span v-if="banEnded(row.item)">
                         <Tooltip :text="$t('ban-ended')">
@@ -63,6 +66,7 @@ import {computed, onMounted, ref} from 'vue';
 import {DateTime} from 'luxon';
 import Table from '/js/components/global/Table.vue';
 import EditBan from '../components/EditBan.vue';
+import {parseDateTime} from '/js/services/timezoneService';
 import {BANNED_USERS_FIELDS} from '/js/constants/reportUserConstants';
 import {useAdminStore} from '/js/store/adminStore';
 const adminStore = useAdminStore();

--- a/resources/js/pages/admin/tabs/BugReportPanel.vue
+++ b/resources/js/pages/admin/tabs/BugReportPanel.vue
@@ -9,6 +9,9 @@
             :sortAsc="!currentSortDesc"
             :options="['table-hover', 'table-sm', 'table-responsive', 'table-striped']"
             class="font-sm">
+            <template #time_created="data">
+                {{parseDateTime(data.item.time_created)}}
+            </template>
             <template #severity="data">
                 <span class="severity">{{ data.item.severity }}</span>
             </template>
@@ -55,6 +58,7 @@ import {BUG_REPORT_OVERVIEW_FIELDS, BUG_DEFAULTS, BUG_STATUS} from '/js/constant
 import {ref, computed} from 'vue';
 import EditBugReport from './../components/EditBugReport.vue';
 import SendMessage from '/js/pages/messages/components/SendMessage.vue';
+import {parseDateTime} from '/js/services/timezoneService';
 import {useMainStore} from '/js/store/store';
 import {useAdminStore} from '/js/store/adminStore';
 const mainStore = useMainStore();

--- a/resources/js/pages/admin/tabs/Feedback.vue
+++ b/resources/js/pages/admin/tabs/Feedback.vue
@@ -12,6 +12,9 @@
                     {{row.item.user.username}}
                 </router-link>
             </template>
+            <template #created_at="row">
+                {{parseDateTime(row.item.created_at)}}
+            </template>
             <template #actions="row">
                 <Tooltip v-if="!row.item.archived" :text="$t('archive')">
                     <FaIcon 
@@ -34,7 +37,7 @@
                 </Tooltip>
             </template>
             <template #archived="row">
-                {{row.item.archived ? row.item.updated_at : ''}}
+                {{row.item.archived ? parseDateTime(row.item.updated_at) : ''}}
             </template>
         </Table>
         <Modal 
@@ -52,6 +55,7 @@ import {ref, onMounted, computed} from 'vue';
 import Table from '/js/components/global/Table.vue';
 import SendMessage from '/js/pages/messages/components/SendMessage.vue';
 import {FEEDBACK_FIELDS} from '/js/constants/feedbackConstants.js';
+import {parseDateTime} from '/js/services/timezoneService';
 import {useAdminStore} from '/js/store/adminStore';
 const adminStore = useAdminStore();
 

--- a/resources/js/pages/admin/tabs/ReportedUsers.vue
+++ b/resources/js/pages/admin/tabs/ReportedUsers.vue
@@ -44,7 +44,7 @@
                             {{user.report_amount}}
                         </div>
                         <div class="col">
-                            {{user.last_report_date}}
+                            {{parseDateTime(user.last_report_date)}}
                         </div>
                         <div class="col">
                             <FaIcon 
@@ -85,10 +85,11 @@
                         <template v-for="(banned, index) in user.banned" :key="index">
                             <div class="row">
                                 <div class="col">
-                                    {{banned.created_at}} ({{banned.time_since}})
+                                    {{parseDateTime(banned.created_at)}} ({{banned.time_since}})
                                 </div>
                                 <div class="col">
-                                    {{banned.early_release ? banned.early_release : banned.banned_until}} 
+                                    {{banned.early_release ? 
+                                        parseDateTime(banned.early_release, true) : parseDateTime(banned.banned_until, true)}} 
                                     ({{banned.banned_until_time}})
                                 </div>
                                 <div class="col">
@@ -124,7 +125,7 @@
                                     {{report.comment}}
                                 </div>
                                 <div class="col">
-                                    {{report.reported_date}}
+                                    {{parseDateTime(report.reported_date)}}
                                 </div>
                                 <div class="col">
                                     {{report.reported_by_name}}
@@ -175,10 +176,12 @@
 </template>
 
 <script setup>
+/* eslint-disable max-lines */
 import {ref, computed, onMounted, onBeforeUpdate} from 'vue';
 import SuspendUserModal from './../components/SuspendUserModal.vue';
 import ShowConversationModal from '../components/ShowConversationModal.vue';
 import SendMessage from '/js/pages/messages/components/SendMessage.vue';
+import {parseDateTime} from '/js/services/timezoneService';
 import {sortValues} from '/js/services/sortService';
 import {DateTime} from 'luxon';
 import {useAdminStore} from '/js/store/adminStore';

--- a/resources/js/pages/messages/Messages.vue
+++ b/resources/js/pages/messages/Messages.vue
@@ -22,7 +22,7 @@
                             <p><strong>{{getSender(conversation.last_message)}}</strong>
                                 {{limitMessage(conversation.last_message.message)}}
                             </p>
-                            <p class="silent mb-0">{{ $t('last-message') }}: {{conversation.updated_at}}</p>
+                            <p class="silent mb-0">{{ $t('last-message') }}: {{parseDateTime(conversation.updated_at)}}</p>
                         </div>
                     </div>
                     <div v-if="activeConversation" class="col m-1 min-col-8">
@@ -89,6 +89,7 @@ import {computed, ref, reactive, onMounted} from 'vue';
 import Message from './components/Message.vue';
 import ReportUser from './components/ReportUser.vue';
 import Dropdown from '/js/components/global/Dropdown.vue';
+import {parseDateTime} from '/js/services/timezoneService';
 
 import {useI18n} from 'vue-i18n'
 const {t} = useI18n() // use as global scope

--- a/resources/js/pages/messages/components/Message.vue
+++ b/resources/js/pages/messages/components/Message.vue
@@ -4,7 +4,7 @@
          @mouseleave="showActionButtons = false">
         <p class="mb-0">{{getSender}} {{message.message}}</p>
         <p class="silent d-flex">
-            {{message.created_at}}
+            {{parseDateTime(message.created_at)}}
             <span v-if="showActionButtons" class="ml-auto"> 
                 <FaIcon 
                     icon="trash"
@@ -17,6 +17,7 @@
 
 <script setup>
 import {computed, ref} from 'vue';
+import {parseDateTime} from '/js/services/timezoneService';
 import {useI18n} from 'vue-i18n'
 const {t} = useI18n() // use as global scope
 

--- a/resources/js/pages/notifications/components/NotificationBlock.vue
+++ b/resources/js/pages/notifications/components/NotificationBlock.vue
@@ -15,7 +15,7 @@
             </template>
             <slot>
                 <p>{{notification.text}}</p>
-                <p>{{ $t('received-on') }}: {{notification.created_at}}</p>
+                <p>{{ $t('received-on') }}: {{parseDateTime(notification.created_at)}}</p>
             </slot>
         </Summary>
     </div>
@@ -24,6 +24,7 @@
 
 <script setup>
 import Summary from '/js/components/global/Summary.vue';
+import {parseDateTime} from '/js/services/timezoneService';
 import {useI18n} from 'vue-i18n'
 import {useMessageStore} from '/js/store/messageStore';
 

--- a/resources/js/pages/overview/components/AchievementsCard.vue
+++ b/resources/js/pages/overview/components/AchievementsCard.vue
@@ -19,6 +19,7 @@
 
 <script setup>
 import Summary from '/js/components/global/Summary.vue';
+import {parseDateTime} from '/js/services/timezoneService';
 import {useI18n} from 'vue-i18n'
 const {t} = useI18n() // use as global scope
 defineProps({
@@ -33,6 +34,6 @@ defineProps({
  */
 function achievementSummary(achievement) {
     return achievement.description+' '+achievement.trigger_description+' '
-    + t('earned-on')+': '+achievement.pivot.earned;
+    + t('earned-on')+': '+parseDateTime(achievement.pivot.earned, true);
 }
 </script>

--- a/resources/js/pages/social/components/GroupDetails.vue
+++ b/resources/js/pages/social/components/GroupDetails.vue
@@ -13,7 +13,7 @@
                     </div>
                     <div class="row mb-1">
                         <div class="col-2"><b>{{ $t('founded') }}: </b></div>
-                        <div class="col-4">{{group.time_created}}</div>
+                        <div class="col-4">{{parseDateTime(group.time_created)}}</div>
                     </div>
                     <div class="row mb-1">
                         <div class="col-2"><b>{{ $t('members') }}:</b></div>
@@ -48,7 +48,7 @@
                     <div v-for="member in group.members" :key="member.id" class="row">
                         <div class="col-2">{{member.username}}</div>
                         <div class="col-2">{{member.rank}}</div>
-                        <div class="col-5">Joined: {{member.joined}}</div>
+                        <div class="col-5">Joined: {{parseDateTime(member.joined, true)}}</div>
                     </div>
                 </div>
             </div>
@@ -68,6 +68,7 @@
 import {computed, ref} from 'vue';
 import ManageGroupModal from './ManageGroupModal.vue';
 import ManageApplicationsModal from './ManageApplicationsModal.vue';
+import {parseDateTime} from '/js/services/timezoneService';
 import {useI18n} from 'vue-i18n'
 const {t} = useI18n() // use as global scope
 import {useGroupStore} from '/js/store/groupStore';

--- a/resources/js/pages/social/tabs/Blocklist.vue
+++ b/resources/js/pages/social/tabs/Blocklist.vue
@@ -16,7 +16,7 @@
                                 {{blockedUser.blocked_user}}
                             </router-link>
                             <span class="col-4">
-                                {{$t('blocked-on')}}: {{blockedUser.created_at}}
+                                {{$t('blocked-on')}}: {{parseDateTime(blockedUser.created_at)}}
                             </span>
                         </li>
                     </div>
@@ -31,8 +31,9 @@
 <script setup>
 import Summary from '/js/components/global/Summary.vue';
 import {onMounted, ref} from 'vue';
-import {useUserStore} from '/js/store/userStore';
+import {parseDateTime} from '/js/services/timezoneService';
 
+import {useUserStore} from '/js/store/userStore';
 const userStore = useUserStore();
 
 onMounted(() => {

--- a/resources/js/services/timezoneService.js
+++ b/resources/js/services/timezoneService.js
@@ -1,0 +1,21 @@
+import {DateTime} from 'luxon';
+
+/**
+ * Parses an ISO string into a localized and timezoned string.
+ * Expects a timestring in ISO format (including timezone)
+ * If it's not an ISO string, set SQLString to true, so it can be rezoned into UTC
+ * 
+ * @param {string} time
+ * @param {boolean} SQLString
+ */
+export function parseDateTime(time, SQLString = false) {
+    // const timezone = localStorage.getItem('timezone') || 'system';
+    // const locale = localStorage.getItem('locale') || 'en-UK';
+    const timezone = 'system';
+    const locale = 'system';
+    if (SQLString) {
+        time = DateTime.fromSQL(time).setZone('UTC', {keepLocalTime: true}).toString();
+    }
+    const date = DateTime.fromISO(time).setZone(timezone).setLocale(locale);
+    return date.toLocaleString(DateTime.DATETIME_MED);
+}


### PR DESCRIPTION
Rather than turning dates into a parsed string in the backend, it now sends as an ISO date, including the timezone (being UTC). In the front-end, it parses this into a localized string.
Pivot table timestamps still end up as strings and as such need to be rezoned. This can be done by adding `true` as second parameter when using `parseDateTime` function.