### PR TITLE
Bug/420 check duplicate friend request accept

### DIFF
--- a/app/Http/Controllers/FriendController.php
+++ b/app/Http/Controllers/FriendController.php
@@ -11,6 +11,7 @@ use App\Http\Resources\UserResource;
 use App\Helpers\AchievementHandler;
 use App\Helpers\ActionTrackingHandler;
 use App\Helpers\NotificationHandler;
+use App\Http\Resources\FriendResource;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -33,7 +34,7 @@ class FriendController extends Controller
         
         ActionTrackingHandler::handleAction($request, 'DELETE_FRIEND', 'Friendship removed');
         return new JsonResponse(['message' => ['info' => 'Friend removed.'], 
-            'user' => new UserResource(Auth::user())], 
+            'friends' => FriendResource::collection(Auth::user()->friends->sortBy('username'))], 
             Response::HTTP_OK);
     }
 
@@ -74,7 +75,7 @@ class FriendController extends Controller
 
         $requests = $this->fetchRequests();
         return new JsonResponse(['message' => ['success' => 'Friend request accepted. You are now friends.'], 
-            'user' => new UserResource(Auth::user()),
+            'friends' => FriendResource::collection(Auth::user()->friends->sortBy('username')),
             'requests' => $requests], 
             Response::HTTP_OK);
     }

--- a/app/Http/Controllers/FriendController.php
+++ b/app/Http/Controllers/FriendController.php
@@ -58,6 +58,8 @@ class FriendController extends Controller
      * Returns all open requests after updating
      */
     public function acceptFriendRequest(Request $request, Friend $friend){
+        if ($friend->accepted)
+            return new JsonResponse(['message' => ['error' => 'You have already accepted this request.']], Response::HTTP_UNPROCESSABLE_ENTITY);
         $friend->accepted = true;
         $friend->update();
         Friend::create(['user_id' => $friend->friend_id, 'friend_id' => $friend->user_id, 'accepted' => true]);
@@ -78,6 +80,8 @@ class FriendController extends Controller
      * Returns the updated list of request
      */
     public function denyFriendRequest(Request $request, Friend $friend){
+        if ($friend->accepted)
+            return new JsonResponse(['message' => ['error' => 'This request does not exist.']], Response::HTTP_UNPROCESSABLE_ENTITY);
         $friend->delete();
         $requests = $this->fetchRequests();
         ActionTrackingHandler::handleAction($request, 'FRIEND_REQUEST', 'Friend request denied');

--- a/resources/js/pages/dashboard/components/FriendsCard.vue
+++ b/resources/js/pages/dashboard/components/FriendsCard.vue
@@ -42,10 +42,7 @@ import {useUserStore} from '/js/store/userStore';
 import {useFriendStore} from '/js/store/friendStore';
 const friendStore = useFriendStore();
 
-const userStore = useUserStore();
-
-const user = computed(() => userStore.user);
-const friends = props.friends ? props.friends : user.value.friends;
+const friends = computed(() => friendStore.friends);
 
 const props = defineProps({
     manage: {
@@ -55,10 +52,6 @@ const props = defineProps({
     message: {
         type: Boolean,
         required: true,
-    },
-    friends: {
-        type: Array,
-        required: false,
     },
 });
 

--- a/resources/js/pages/dashboard/components/FriendsCard.vue
+++ b/resources/js/pages/dashboard/components/FriendsCard.vue
@@ -39,6 +39,9 @@ import Summary from '/js/components/global/Summary.vue';
 import {computed, ref} from 'vue';
 import {useUserStore} from '/js/store/userStore';
 
+import {useFriendStore} from '/js/store/friendStore';
+const friendStore = useFriendStore();
+
 const userStore = useUserStore();
 
 const user = computed(() => userStore.user);
@@ -71,7 +74,7 @@ function closeSendMessageModal() {
 
 function removeFriend(friend) {
     if (confirm('Are you sure you wish to remove ' + friend.username + ' as friend?')) {
-        this.$store.dispatch('friend/removeFriend', friend.friendship_id);
+        friendStore.removeFriend(friend.friendship_id);
     }
 }
 </script>

--- a/resources/js/pages/notifications/components/NotificationBlock.vue
+++ b/resources/js/pages/notifications/components/NotificationBlock.vue
@@ -38,8 +38,8 @@ import Summary from '/js/components/global/Summary.vue';
 import {parseDateTime} from '/js/services/dateService';
 import {useI18n} from 'vue-i18n';
 import {useMessageStore} from '/js/store/messageStore';
-import axios from 'axios';
 import {computed} from 'vue';
+import {handleNotificationLink} from '/js/services/notificationLinkService';
 
 const {t} = useI18n();
 const messageStore = useMessageStore();
@@ -72,12 +72,7 @@ function deleteNotification() {
  * @param {String} linkUrl
  */
 async function linkAction(apiType, linkUrl) {
-    if (apiType == 'POST')
-        axios.post(linkUrl);
-    else if (apiType == 'PUT')
-        axios.put(linkUrl);
-    else if (apiType == 'DELETE')
-        axios.delete(linkUrl);
+    handleNotificationLink(apiType, linkUrl);
     if (prop.notification.delete_links_on_action)
         await messageStore.deleteNotificationAction(prop.notification.id);
 }

--- a/resources/js/pages/social/components/FriendRequests.vue
+++ b/resources/js/pages/social/components/FriendRequests.vue
@@ -59,18 +59,18 @@ const requests = computed(() => friendStore.requests);
  * @param {Number} requestId
  */
 function removeFriendRequest(requestId) {
-    useFriendStore.removeRequest(requestId);
+    friendStore.removeRequest(requestId);
 }
 /**
  * @param {Number} requestId
  */
 function denyFriendRequest(requestId) {
-    useFriendStore.denyRequest(requestId);
+    friendStore.denyRequest(requestId);
 }
 /**
  * @param {Number} requestId
  */
 function acceptFriendRequest(requestId) {
-    useFriendStore.acceptRequest(requestId);
+    friendStore.acceptRequest(requestId);
 }
 </script>

--- a/resources/js/services/notificationLinkService.js
+++ b/resources/js/services/notificationLinkService.js
@@ -1,0 +1,56 @@
+import axios from 'axios';
+import {useFriendStore} from '/js/store/friendStore';
+
+/**
+ * Handles all notification links. Checks what the url type is (eg 'friend')
+ * and handles accordingly. All other types are handled as direct back-end link
+ * 
+ * @param {string} apiType
+ * @param {string} url
+ */
+export function handleNotificationLink(apiType, url) {
+    const urlType = url.split('/')[1];
+    switch (urlType) {
+        case 'friend':
+            handleFriendRequests(url);
+            break;
+        default:
+            handleOtherLinks(apiType, url);
+            break;
+    }
+}
+
+/**
+ * Handles the friend requests. It takes the type of action (accept/deny) out of
+ * the url, as well as the request ID, and uses the friendStore to handle the action.
+ * This way the friends are still sent back to the store, updated.
+ * 
+ * @param {string} url
+ */
+function handleFriendRequests(url) {
+    const action = url.split('/')[4];
+    const requestId = parseInt(url.split('/')[3]);
+    const friendStore = useFriendStore();
+    if (action == 'accept')
+        friendStore.acceptRequest(requestId);
+    else if (action == 'deny')
+        friendStore.denyRequest(requestId);
+
+}
+
+/**
+ * Handles all other links as direct back-end calls as per their api type.
+ * 
+ * @param {string} apiType
+ * @param {string} url
+ */
+function handleOtherLinks(apiType, url) {
+    if (apiType == 'POST')
+        axios.post(url);
+    else if (apiType == 'PUT')
+        axios.put(url);
+    else if (apiType == 'DELETE')
+        axios.delete(url);
+}
+
+

--- a/resources/js/store/friendStore.js
+++ b/resources/js/store/friendStore.js
@@ -1,12 +1,13 @@
 import axios from 'axios';
 import {defineStore} from 'pinia';
-import {useUserStore} from './userStore';
 
 export const useFriendStore = defineStore('friend', {
     state: () => {
         return {
             /** @type Array<import('resources/types/friend').Friend> | null */
             requests: null,
+            /** @type Array<import('resources/types/friend').Friend> | null */
+            friends: [],
         }
     },
     actions: {
@@ -25,8 +26,7 @@ export const useFriendStore = defineStore('friend', {
          */
         async acceptRequest(requestId) {
             const {data} = await axios.post('/friend/request/' + requestId + '/accept');
-            const userStore = useUserStore();
-            userStore.user = data.user;
+            this.friends = data.friends;
             this.requests = data.requests;
         },
         /**
@@ -48,8 +48,7 @@ export const useFriendStore = defineStore('friend', {
          */
         async removeFriend(friendId) {
             const {data} = await axios.delete('/friend/remove/' + friendId);
-            const userStore = useUserStore();
-            userStore.user = data.user;
+            this.friends = data.friends;
         },
     },
 });

--- a/resources/js/store/userStore.js
+++ b/resources/js/store/userStore.js
@@ -4,6 +4,7 @@ import router from '../router/router';
 import {useRewardStore} from './rewardStore';
 import {useMessageStore} from './messageStore';
 import {useAchievementStore} from './achievementStore';
+import {useFriendStore} from './friendStore';
 
 export const useUserStore = defineStore('user', {
     state: () => {
@@ -32,6 +33,8 @@ export const useUserStore = defineStore('user', {
             const {data} = await axios.post('/login', user);
             if (data.invalid) return data.message;
             this.setUser(data.user);
+            const friendStore = useFriendStore();
+            friendStore.friends = data.user.friends;
             router.push('/dashboard').catch(() => {});
         },
 


### PR DESCRIPTION
Resolves #420 

Also makes changes to the notification link, as it did not account for changes in friends, updating the actual friend list. Friends are now in its own friendStore, are set upon login and will change accordingly when requests are accepted etc.