### PR TITLE
Some ts, profile bug fix and 404 catch all

### DIFF
--- a/app/Http/Resources/AchievementEarnedResource.php
+++ b/app/Http/Resources/AchievementEarnedResource.php
@@ -19,7 +19,7 @@ class AchievementEarnedResource extends JsonResource
             'name' => $this->name,
             'description' => $this->description,
             'trigger_description' => $this->trigger_description,
-            'earned' => Carbon::create($this->pivot->earned),
+            'earned' => $this->pivot->earned,
         ];
     }
 }

--- a/resources/js/pages/overview/components/AchievementsCard.vue
+++ b/resources/js/pages/overview/components/AchievementsCard.vue
@@ -17,23 +17,23 @@
 </template>
 
 
-<script setup>
+<script setup lang="ts">
 import Summary from '/js/components/global/Summary.vue';
 import {parseDateTime} from '/js/services/dateService';
 import {useI18n} from 'vue-i18n'
+import {Achievement} from 'resources/types/achievement';
+import {PropType} from 'vue';
 const {t} = useI18n() // use as global scope
 defineProps({
     achievements: {
-        type: Array,
+        type: Array as PropType<Array<Achievement>>,
         required: false,
     },
 });
-/**
- * @param {import('resources/types/achievement').Achievement} achievement
- * @return {string}
- */
-function achievementSummary(achievement) {
+
+function achievementSummary(achievement: Achievement): string {
+    const date = achievement.pivot ? parseDateTime(achievement.pivot.earned, true) : '';
     return achievement.description+' '+achievement.trigger_description+' '
-    + t('earned-on')+': '+parseDateTime(achievement.earned);
+    + t('earned-on')+': '+ date;
 }
 </script>

--- a/resources/js/router/router.js
+++ b/resources/js/router/router.js
@@ -34,6 +34,7 @@ let routes = [
         meta: {requiresAuth: true},
     },
     {
+        name: 'login',
         path: '/login',
         component: Login,
     },
@@ -100,6 +101,7 @@ let routes = [
         component: Feedback,
     },
     {
+        name: 'Error',
         path: '/:pathMatch(.*)*',
         component: ErrorPage,
     },


### PR DESCRIPTION
- Fixed a few ts errors
- Fixed a bug that blocked me from seeing a profile. Had to do with the nature of the timestamp of `earned` on achievements being an SQL string, rather than an ISO string. Should not cause further issues
- Added a catch all for 404's. The better option would be to have specific 404 catches for when you click a group/user that just got deleted, for instance, to show "This user does not exist", rather than "This page does not exist".