### PR TITLE
Switched from localstor to fetching the user before mount

### DIFF
--- a/app/Http/Controllers/AuthenticationController.php
+++ b/app/Http/Controllers/AuthenticationController.php
@@ -44,7 +44,13 @@ class AuthenticationController extends Controller
         return ResponseWrapper::errorResponse(__('auth.failed'));
     }
 
-    private function handleBannedUser(User $user, Request $request)
+    /**
+     * Handles a banned user by logging its attempt and parsing the ban message to the user to show on the login screen.
+     *
+     * @param User $user
+     * @param Request $request
+     */
+    private function handleBannedUser(User $user, Request $request): JsonResponse
     {
         $timeRemaining = Carbon::parse($user->banned_until)->diffForHumans(Carbon::now(), ['syntax' => CarbonInterface::DIFF_RELATIVE_TO_NOW]);
         ActionTrackingHandler::handleAction($request, 'LOGIN', 'Banned user attepted logging in ' . $request['username']);
@@ -67,7 +73,14 @@ class AuthenticationController extends Controller
         return;
     }
 
-    public function getResetPasswordLink(SendResetPasswordEmailRequest $request)
+    /**
+     * Creates a password reset link. To not show to the user whether that user/email exists, always confirm
+     * unless there was another technical error. This way a hacker cannot guess an e-mail or try multiple until
+     * an email is confirmed.
+     *
+     * @param SendResetPasswordEmailRequest $request
+     */
+    public function getResetPasswordLink(SendResetPasswordEmailRequest $request): JsonResponse
     {
         $validated = $request->validated();
         $status = Password::sendResetLink($validated);
@@ -78,6 +91,11 @@ class AuthenticationController extends Controller
             return ResponseWrapper::errorResponse('Something went wrong. Try again later or contact an admin.');
     }
 
+    /** 
+     * Resets the password using the previously provided link 
+     * 
+     * @param ResetPasswordRequest $request
+     */
     public function resetPassword(ResetPasswordRequest $request)
     {
         $validated = $request->validated();
@@ -102,5 +120,16 @@ class AuthenticationController extends Controller
             return ResponseWrapper::errorResponse('Invalid user. Check your e-mailaddress and try again.');
         else
             return ResponseWrapper::errorResponse('Something went wrong. Try again later or contact an admin.');
+    }
+
+    /**
+     * Checks if the user is logged in, and if so, returns the user. If not, returns a null
+     */
+    public function me(): JsonResponse
+    {
+        if (Auth::check()) {
+            return new JsonResponse(['user' => new UserResource(Auth::user())]);
+        }
+        return new JsonResponse(['user' => null]);
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -25,6 +25,10 @@ const app = createApp(App);
 import {createPinia} from 'pinia';
 app.use(createPinia());
 
+import {useUserStore} from './store/userStore';
+const userStore = useUserStore();
+await userStore.getMe();
+
 //Import router
 import router from './router/router';
 app.use(router);
@@ -56,6 +60,5 @@ import Textarea from '/js/components/global/Textarea.vue';
 app.component('SimpleTextarea', Textarea);
 import Tutorial from '/js/components/global/Tutorial.vue';
 app.component('Tutorial', Tutorial);
-
 
 app.mount('#app');

--- a/resources/js/components/Navigation.vue
+++ b/resources/js/components/Navigation.vue
@@ -83,7 +83,7 @@ onMounted(() => window.addEventListener('resize', handleResize));
 const userStore = useUserStore();
 const messageStore = useMessageStore();
 
-const authenticated = computed(() => userStore.isAuthenticated);
+const authenticated = computed(() => userStore.authenticated);
 const user = computed(() => userStore.user);
 const hasNotifications = computed(() => messageStore.hasNotifications);
 const hasMessages = computed(() => messageStore.hasMessages);

--- a/resources/js/interceptors.ts
+++ b/resources/js/interceptors.ts
@@ -31,6 +31,7 @@ axios.interceptors.response.use(
     },
     // eslint-disable-next-line complexity
     function (error) {
+        const userStore = useUserStore();
         const mainStore = useMainStore();
         if (!error.response) {
             return Promise.reject(error);
@@ -60,7 +61,6 @@ axios.interceptors.response.use(
              */
             case 401:
                 if (router.currentRoute.value.name !== 'login') {
-                    const userStore = useUserStore();
                     userStore.logout();
                 }
                 errorToast('You are not logged in');
@@ -71,6 +71,7 @@ axios.interceptors.response.use(
              * router will already redirect them, this is backup.
              */
             case 403:
+                userStore.getMe();
                 if (router.currentRoute.value.name !== 'login') {
                     router.push('/dashboard');
                 }

--- a/resources/js/pages/Feedback.vue
+++ b/resources/js/pages/Feedback.vue
@@ -40,7 +40,7 @@ const feedback = ref<NewFeedback>({
 const feedbackTypes = FEEDBACK_TYPES;
 
 const user = computed(() => userStore.user);
-const auth = computed(() => userStore.isAuthenticated);
+const auth = computed(() => userStore.authenticated);
 
 async function sendFeedback() {
     if (user.value) {

--- a/resources/js/router/router.ts
+++ b/resources/js/router/router.ts
@@ -26,15 +26,15 @@ router.beforeEach((to, from, next) => {
         document.title = 'Questifyer';
     }
     
-    if (to.path == '/' && userStore.isAuthenticated) {
+    if (to.path == '/' && userStore.authenticated) {
         return next({path: '/dashboard'});
     }
 
-    if (to.path != '/welcome' && userStore.user.first) {
+    if (to.path != '/welcome' && userStore.user && userStore.user.first) {
         return next({path: '/welcome'});
     }
 
-    if (to.meta && to.meta.requiresAuth && !userStore.isAuthenticated) {
+    if (to.meta && to.meta.requiresAuth && !userStore.authenticated) {
         return next({path: '/login'});
     }
 
@@ -43,7 +43,7 @@ router.beforeEach((to, from, next) => {
         return next({path: '/dashboard'});
     }
     
-    if (userStore.isAuthenticated) {
+    if (userStore.authenticated) {
         messageStore.hasUnread();
     }
     next();

--- a/resources/types/user.d.ts
+++ b/resources/types/user.d.ts
@@ -7,7 +7,7 @@ import {ReportedUser} from './admin';
 export type User = {
     id: number;
     username: string;
-    admin: boolean;
+    admin?: boolean;
     email: string;
     first: boolean;
     rewards: string;

--- a/routes/api.php
+++ b/routes/api.php
@@ -39,6 +39,8 @@ foreach ($routes as $route) {
 }
 
 Route::group(['middleware' => ['web']], function () {
+    Route::get('/me', [AuthenticationController::class, 'me']);
+
     Route::post('/login', [AuthenticationController::class, 'authenticate']);
     Route::post('/logout', [AuthenticationController::class, 'logout']);
     Route::post('/register', [RegisteredUserController::class, 'store']);


### PR DESCRIPTION
Resolves #485 

Removed the local storage aspect of saving the user and its authentication. Now before mounting the app, fetch the user, thus checking if it is authenticated. This may also reduce the 'You are not logged in' toasts, as it doesn't assume the user is authenticated before firing off a 'dashboard' and 'unread' API call.