### PR TITLE
Bugfix/853 confirmmodal

### DIFF
--- a/app/Http/Controllers/AchievementController.php
+++ b/app/Http/Controllers/AchievementController.php
@@ -58,5 +58,6 @@ class AchievementController extends Controller
     {
         $achievement->achievementsEarned()->delete();
         $achievement->delete();
+        return ResponseWrapper::successResponse(__('messages.achievement.deleted'), ['achievements' => AchievementResource::collection(Achievement::get())]);
     }
 }

--- a/app/Http/Requests/StoreAchievementRequest.php
+++ b/app/Http/Requests/StoreAchievementRequest.php
@@ -29,7 +29,7 @@ class StoreAchievementRequest extends FormRequest
             'name' => 'required|string|max:255',
             'description' => 'nullable|string',
             'trigger_type' => ['required', new ExistingAchievementType()],
-            'trigger_amount' => 'required|integer',
+            'trigger_amount' => 'required|integer|max:9999999999',
         ];
     }
 }

--- a/resources/js/components/modal/ConfirmModal.vue
+++ b/resources/js/components/modal/ConfirmModal.vue
@@ -12,7 +12,7 @@
                         {{ modal.text }}
                         <div class="d-flex">
                             <button class="ml-auto mr-2 cancel-button" @click="$emit('close')">{{ modal.cancelText }}</button>
-                            <button type="submit" @click="modal.confirmFunction">{{ modal.confirmText }}</button>
+                            <button type="submit" @click="confirm">{{ modal.confirmText }}</button>
                         </div>
                     </div>
                 </div>
@@ -25,9 +25,15 @@
 import {ref} from 'vue';
 import {ConfirmModal} from './modals';
 
-defineProps<{modal: ConfirmModal}>();
+const props = defineProps<{modal: ConfirmModal}>();
 
-defineEmits(['close']);
+const emit = defineEmits(['close']);
+
+const confirm = async () => {
+    await props.modal.confirmFunction();
+
+    emit('close');
+}
 
 const modalTemplate = ref<HTMLDivElement>();
 </script>


### PR DESCRIPTION
Resolves #853 

Also solves the issue of achievements not refreshing when deleting one
Also solves the issue of an exceedingly high number in the trigger field for a new achievement not being caught by validation, thus failing in the DB.